### PR TITLE
[ETFE-2912] - Default fixed transport (TU) when its selected on the Journey Type pages

### DIFF
--- a/app/controllers/sections/transportUnit/TransportUnitIndexController.scala
+++ b/app/controllers/sections/transportUnit/TransportUnitIndexController.scala
@@ -18,8 +18,10 @@ package controllers.sections.transportUnit
 
 import controllers.BaseNavigationController
 import controllers.actions._
+import models.sections.journeyType.HowMovementTransported.FixedTransportInstallations
 import models.{Index, NormalMode}
 import navigation.TransportUnitNavigator
+import pages.sections.journeyType.HowMovementTransportedPage
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import queries.TransportUnitsCount
@@ -40,11 +42,15 @@ class TransportUnitIndexController @Inject()(
 
   def onPageLoad(ern: String, draftId: String): Action[AnyContent] =
     authorisedDataRequest(ern, draftId) { implicit request =>
-      request.userAnswers.get(TransportUnitsCount) match {
-        case None | Some(0) => Redirect(
+      (request.userAnswers.get(TransportUnitsCount), request.userAnswers.get(HowMovementTransportedPage)) match {
+        //TODO: redirect to CAM-TU9 / CAM-TU09
+        case (_, Some(FixedTransportInstallations)) => Redirect(
+          testOnly.controllers.routes.UnderConstructionController.onPageLoad()
+        )
+        case (None | Some(0), _) => Redirect(
           controllers.sections.transportUnit.routes.TransportUnitTypeController.onPageLoad(request.ern, request.draftId, Index(0), NormalMode)
         )
-        case Some(_) => Redirect(
+        case (Some(_), _) => Redirect(
           controllers.sections.transportUnit.routes.TransportUnitsAddToListController.onPageLoad(request.ern, request.draftId)
         )
       }

--- a/app/navigation/TransportUnitNavigator.scala
+++ b/app/navigation/TransportUnitNavigator.scala
@@ -18,6 +18,7 @@ package navigation
 
 import controllers.routes
 import controllers.sections.transportUnit.{routes => transportUnitRoutes}
+import models.sections.transportUnit.TransportUnitType.FixedTransport
 import models.sections.transportUnit.TransportUnitsAddToListModel
 import models.{CheckMode, Index, Mode, NormalMode, ReviewMode, UserAnswers}
 import pages.Page
@@ -31,7 +32,11 @@ class TransportUnitNavigator @Inject() extends BaseNavigator {
 
   private val normalRoutes: Page => UserAnswers => Call = {
     case TransportUnitTypePage(idx) => (userAnswers: UserAnswers) =>
-      transportUnitRoutes.TransportUnitIdentityController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
+      if(userAnswers.get(TransportUnitTypePage(idx)).contains(FixedTransport)) {
+        testOnly.controllers.routes.UnderConstructionController.onPageLoad()
+      } else {
+        transportUnitRoutes.TransportUnitIdentityController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
+      }
     case TransportUnitIdentityPage(idx) => (userAnswers: UserAnswers) =>
       transportUnitRoutes.TransportSealChoiceController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
 

--- a/app/pages/sections/transportUnit/TransportUnitsSection.scala
+++ b/app/pages/sections/transportUnit/TransportUnitsSection.scala
@@ -17,8 +17,10 @@
 package pages.sections.transportUnit
 
 import models.requests.DataRequest
+import models.sections.journeyType.HowMovementTransported.FixedTransportInstallations
 import models.sections.transportUnit.TransportUnitsAddToListModel
 import pages.sections.Section
+import pages.sections.journeyType.HowMovementTransportedPage
 import play.api.libs.json.{JsObject, JsPath}
 import queries.TransportUnitsCount
 import viewmodels.taskList.{Completed, InProgress, TaskListStatus}
@@ -29,13 +31,17 @@ case object TransportUnitsSection extends Section[JsObject] {
   val MAX: Int = 99
 
   override def status(implicit request: DataRequest[_]): TaskListStatus = {
-    (TransportUnitsSectionUnits.status, request.userAnswers.get(TransportUnitsAddToListPage), request.userAnswers.get(TransportUnitsCount)) match {
-      case (Completed, _, Some(MAX)) => Completed
-      case (Completed, Some(TransportUnitsAddToListModel.NoMoreToCome), _) => Completed
-      case (Completed, Some(TransportUnitsAddToListModel.MoreToCome) | None, _) => InProgress
-      case (Completed, Some(TransportUnitsAddToListModel.Yes) | None, _) => InProgress
-      case (InProgress, _, _) => InProgress
-      case (status, _, _) => status
+    (TransportUnitsSectionUnits.status,
+      request.userAnswers.get(TransportUnitsAddToListPage),
+      request.userAnswers.get(TransportUnitsCount),
+      request.userAnswers.get(HowMovementTransportedPage)) match {
+      case (_, _, Some(MAX), _) => Completed
+      case (_, _, Some(1), Some(FixedTransportInstallations)) => Completed
+      case (Completed, Some(TransportUnitsAddToListModel.NoMoreToCome), _, _) => Completed
+      case (Completed, Some(TransportUnitsAddToListModel.MoreToCome) | None, _, _) => InProgress
+      case (Completed, Some(TransportUnitsAddToListModel.Yes) | None, _, _) => InProgress
+      case (InProgress, _, _, _) => InProgress
+      case (status, _, _, _) => status
     }
   }
 

--- a/test/controllers/sections/journeyType/HowMovementTransportedControllerSpec.scala
+++ b/test/controllers/sections/journeyType/HowMovementTransportedControllerSpec.scala
@@ -22,10 +22,13 @@ import controllers.routes
 import forms.sections.journeyType.HowMovementTransportedFormProvider
 import mocks.services.MockUserAnswersService
 import models.sections.journeyType.HowMovementTransported
+import models.sections.transportUnit.TransportUnitType.{Container, Tractor}
 import models.{NormalMode, UserAnswers}
 import navigation.FakeNavigators.FakeJourneyTypeNavigator
 import pages.sections.journeyType.{GiveInformationOtherTransportPage, HowMovementTransportedPage, JourneyTimeDaysPage}
+import pages.sections.transportUnit.{TransportUnitIdentityPage, TransportUnitTypePage, TransportUnitsSection}
 import play.api.data.Form
+import play.api.libs.json.Json
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
@@ -112,9 +115,14 @@ class HowMovementTransportedControllerSpec extends SpecBase with MockUserAnswers
         .set(HowMovementTransportedPage, HowMovementTransported.Other)
         .set(GiveInformationOtherTransportPage, "blah")
         .set(JourneyTimeDaysPage, 1)
+        .set(TransportUnitTypePage(testIndex1), Container)
+        .set(TransportUnitIdentityPage(testIndex1), "Container1")
+        .set(TransportUnitTypePage(testIndex2), Tractor)
+        .set(TransportUnitIdentityPage(testIndex2), "Tractor")
     )) {
       val expectedAnswers = emptyUserAnswers
         .set(HowMovementTransportedPage, HowMovementTransported.values.head)
+        .set(TransportUnitsSection, Json.obj())
 
       MockUserAnswersService.set(expectedAnswers).returns(Future.successful(expectedAnswers))
 

--- a/test/controllers/sections/transportUnit/TransportUnitIndexControllerSpec.scala
+++ b/test/controllers/sections/transportUnit/TransportUnitIndexControllerSpec.scala
@@ -19,9 +19,11 @@ package controllers.sections.transportUnit
 import base.SpecBase
 import controllers.actions.FakeDataRetrievalAction
 import mocks.services.MockUserAnswersService
+import models.sections.journeyType.HowMovementTransported.FixedTransportInstallations
 import models.sections.transportUnit.TransportUnitType
 import models.{NormalMode, UserAnswers}
 import navigation.TransportUnitNavigator
+import pages.sections.journeyType.HowMovementTransportedPage
 import pages.sections.transportUnit.TransportUnitTypePage
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.Helpers._
@@ -47,13 +49,23 @@ class TransportUnitIndexControllerSpec extends SpecBase with MockUserAnswersServ
 
   "transportUnitIndex Controller" - {
 
+    "must redirect to the transport unit check answers page (CAM-TU09) when the journey type is " +
+      "Fixed Transport Installations" in new Test(Some(emptyUserAnswers.set(HowMovementTransportedPage, FixedTransportInstallations))) {
+
+      val result = controller.onPageLoad(testErn, testDraftId)(request)
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustBe
+        testOnly.controllers.routes.UnderConstructionController.onPageLoad().url
+    }
+
     "must redirect to the transport unit type page (CAM-TU01) when no transport units answered" in new Test(Some(emptyUserAnswers)) {
 
       val result = controller.onPageLoad(testErn, testDraftId)(request)
 
       status(result) mustEqual SEE_OTHER
-      redirectLocation(result) mustBe
-        Some(routes.TransportUnitTypeController.onPageLoad(testErn, testDraftId, testIndex1, NormalMode).url)
+      redirectLocation(result).value mustBe
+        routes.TransportUnitTypeController.onPageLoad(testErn, testDraftId, testIndex1, NormalMode).url
     }
 
     "must redirect to the transport unit type page (CAM-TU01) when there is an empty transport unit list" in new Test(Some(
@@ -73,8 +85,8 @@ class TransportUnitIndexControllerSpec extends SpecBase with MockUserAnswersServ
       val result = controller.onPageLoad(testErn, testDraftId)(request)
 
       status(result) mustEqual SEE_OTHER
-      redirectLocation(result) mustBe
-        Some(routes.TransportUnitsAddToListController.onPageLoad(testErn, testDraftId).url)
+      redirectLocation(result).value mustBe
+        routes.TransportUnitsAddToListController.onPageLoad(testErn, testDraftId).url
     }
   }
 }

--- a/test/navigation/TransportUnitNavigatorSpec.scala
+++ b/test/navigation/TransportUnitNavigatorSpec.scala
@@ -20,8 +20,8 @@ import base.SpecBase
 import controllers.routes
 import controllers.sections.transportUnit.{routes => transportUnitRoutes}
 import fixtures.TransportUnitFixtures
-import models.sections.transportUnit.TransportUnitType.Tractor
-import models.sections.transportUnit.TransportUnitsAddToListModel
+import models.sections.transportUnit.TransportUnitType.{FixedTransport, Tractor}
+import models.sections.transportUnit.{TransportUnitType, TransportUnitsAddToListModel}
 import models.{CheckMode, Index, NormalMode, ReviewMode}
 import pages.Page
 import pages.sections.transportUnit._
@@ -39,11 +39,21 @@ class TransportUnitNavigatorSpec extends SpecBase with TransportUnitFixtures {
 
     "for the TransportUnitType (CAM-TU01)" - {
 
-      "must go to CAM-TU02" in {
-        val userAnswers = emptyUserAnswers.set(TransportUnitTypePage(testIndex1), Tractor)
+      TransportUnitType.values.filterNot(_ == FixedTransport).foreach { transportUnit =>
+        s"must go to CAM-TU02 when the TU type is $transportUnit" in {
+          val userAnswers = emptyUserAnswers.set(TransportUnitTypePage(testIndex1), Tractor)
+
+          navigator.nextPage(TransportUnitTypePage(testIndex1), NormalMode, userAnswers) mustBe
+            transportUnitRoutes.TransportUnitIdentityController.onPageLoad(testErn, testDraftId, Index(0), NormalMode)
+        }
+      }
+
+      //TODO: redirect to CAM-TU09
+      s"must go to CAM-TU09 when the TU type is FixedTransport" in {
+        val userAnswers = emptyUserAnswers.set(TransportUnitTypePage(testIndex1), FixedTransport)
 
         navigator.nextPage(TransportUnitTypePage(testIndex1), NormalMode, userAnswers) mustBe
-          transportUnitRoutes.TransportUnitIdentityController.onPageLoad(testErn, testDraftId, Index(0), NormalMode)
+         testOnly.controllers.routes.UnderConstructionController.onPageLoad()
       }
     }
 

--- a/test/pages/sections/transportUnit/TransportUnitsSectionSpec.scala
+++ b/test/pages/sections/transportUnit/TransportUnitsSectionSpec.scala
@@ -19,8 +19,10 @@ package pages.sections.transportUnit
 import base.SpecBase
 import models.Index
 import models.requests.DataRequest
-import models.sections.transportUnit.TransportUnitType.{Container, Tractor}
+import models.sections.journeyType.HowMovementTransported.FixedTransportInstallations
+import models.sections.transportUnit.TransportUnitType.{Container, FixedTransport, Tractor}
 import models.sections.transportUnit.TransportUnitsAddToListModel.{MoreToCome, NoMoreToCome}
+import pages.sections.journeyType.HowMovementTransportedPage
 import play.api.libs.json.{JsArray, Json}
 import play.api.test.FakeRequest
 import viewmodels.taskList.{Completed, InProgress, NotStarted}
@@ -44,9 +46,20 @@ class TransportUnitsSectionSpec extends SpecBase {
           )
         TransportUnitsSection.isCompleted mustBe true
       }
+
+      "when the journey type is Fixed Transport Installations and the number of transport units is 1" in {
+        implicit val dr: DataRequest[_] =
+          dataRequest(FakeRequest(),
+            emptyUserAnswers
+              .set(HowMovementTransportedPage, FixedTransportInstallations)
+              .set(TransportUnitTypePage(testIndex1), FixedTransport)
+          )
+        TransportUnitsSection.isCompleted mustBe true
+      }
     }
 
     "must return false" - {
+
       "when empty user answers" in {
         implicit val dr: DataRequest[_] = dataRequest(FakeRequest(), emptyUserAnswers)
         TransportUnitsSection.isCompleted mustBe false
@@ -67,6 +80,17 @@ class TransportUnitsSectionSpec extends SpecBase {
               .set(TransportUnitTypePage(testIndex2), Container)
               .set(TransportUnitIdentityPage(testIndex2), "")
               .set(TransportSealChoicePage(testIndex2), false)
+          )
+        TransportUnitsSection.isCompleted mustBe false
+      }
+
+      "when the journey type is Fixed Transport Installations and the number of transport units is > 1" in {
+        implicit val dr: DataRequest[_] =
+          dataRequest(FakeRequest(),
+            emptyUserAnswers
+              .set(HowMovementTransportedPage, FixedTransportInstallations)
+              .set(TransportUnitTypePage(testIndex1), FixedTransport)
+              .set(TransportUnitTypePage(testIndex2), Container)
           )
         TransportUnitsSection.isCompleted mustBe false
       }


### PR DESCRIPTION
User selects Fixed Transport on Journey Type page, then remove all the other transport units entered and set the TU type to Fixed transport.

If the user selects a different answer on the Journey Type page (goes from, Fixed transport to Rail transport), all of the TU answers are cleared