### PR TITLE
ETFE-2926 Remove Guarantor address when of a specific guarantor type - bugfix

### DIFF
--- a/app/models/submitCreateMovement/MovementGuaranteeModel.scala
+++ b/app/models/submitCreateMovement/MovementGuaranteeModel.scala
@@ -24,7 +24,7 @@ import utils.ModelConstructorHelpers
 
 case class MovementGuaranteeModel(
                                    guarantorTypeCode: GuarantorArranger,
-                                   guarantorTrader: Option[TraderModel]
+                                   guarantorTrader: Option[Seq[TraderModel]]
                                  )
 
 object MovementGuaranteeModel extends ModelConstructorHelpers {
@@ -41,7 +41,7 @@ object MovementGuaranteeModel extends ModelConstructorHelpers {
       val guarantorArranger: GuarantorArranger = mandatoryPage(GuarantorArrangerPage)
       MovementGuaranteeModel(
         guarantorTypeCode = guarantorArranger,
-        guarantorTrader = TraderModel.applyGuarantor(guarantorArranger)
+        guarantorTrader = TraderModel.applyGuarantor(guarantorArranger).flatMap(trader => Some(Seq(trader)))
       )
     }
 

--- a/test-utils/fixtures/ItemFixtures.scala
+++ b/test-utils/fixtures/ItemFixtures.scala
@@ -499,13 +499,13 @@ trait ItemFixtures {
     ),
     movementGuarantee = MovementGuaranteeModel(
       guarantorTypeCode = GuarantorArranger.GoodsOwner,
-      guarantorTrader = Some(TraderModel(
+      guarantorTrader = Some(Seq(TraderModel(
         traderExciseNumber = None,
         traderName = Some("guarantor name"),
         address = Some(AddressModel.fromUserAddress(testUserAddress.copy(street = "guarantor street"))),
         vatNumber = Some("guarantor vat"),
         eoriNumber = None
-      ))
+      )))
     ),
     bodyEadEsad = Seq(BodyEadEsadModel(
       bodyRecordUniqueReference = 1,
@@ -631,13 +631,13 @@ trait ItemFixtures {
     ),
     movementGuarantee = MovementGuaranteeModel(
       guarantorTypeCode = GuarantorArranger.GoodsOwner,
-      guarantorTrader = Some(TraderModel(
+      guarantorTrader = Some(Seq(TraderModel(
         traderExciseNumber = None,
         traderName = Some("guarantor name"),
         address = Some(AddressModel.fromUserAddress(testUserAddress.copy(street = "guarantor street"))),
         vatNumber = Some("guarantor vat"),
         eoriNumber = None
-      ))
+      )))
     ),
     bodyEadEsad = Seq(BodyEadEsadModel(
       bodyRecordUniqueReference = 1,
@@ -757,13 +757,13 @@ trait ItemFixtures {
     ),
     movementGuarantee = MovementGuaranteeModel(
       guarantorTypeCode = GuarantorArranger.GoodsOwner,
-      guarantorTrader = Some(TraderModel(
+      guarantorTrader = Some(Seq(TraderModel(
         traderExciseNumber = None,
         traderName = Some("guarantor name"),
         address = Some(AddressModel.fromUserAddress(testUserAddress.copy(street = "guarantor street"))),
         vatNumber = Some("guarantor vat"),
         eoriNumber = None
-      ))
+      )))
     ),
     bodyEadEsad = Seq(BodyEadEsadModel(
       bodyRecordUniqueReference = 1,
@@ -889,13 +889,13 @@ trait ItemFixtures {
     ),
     movementGuarantee = MovementGuaranteeModel(
       guarantorTypeCode = GuarantorArranger.GoodsOwner,
-      guarantorTrader = Some(TraderModel(
+      guarantorTrader = Some(Seq(TraderModel(
         traderExciseNumber = None,
         traderName = Some("guarantor name"),
         address = Some(AddressModel.fromUserAddress(testUserAddress.copy(street = "guarantor street"))),
         vatNumber = Some("guarantor vat"),
         eoriNumber = None
-      ))
+      )))
     ),
     bodyEadEsad = Seq(BodyEadEsadModel(
       bodyRecordUniqueReference = 1,

--- a/test/models/submitCreateMovement/MovementGuaranteeModelSpec.scala
+++ b/test/models/submitCreateMovement/MovementGuaranteeModelSpec.scala
@@ -49,13 +49,13 @@ class MovementGuaranteeModelSpec extends SpecBase {
             .set(GuarantorVatPage, "vat")
         )
 
-        MovementGuaranteeModel.apply mustBe MovementGuaranteeModel(GuarantorArranger.GoodsOwner, Some(TraderModel(
+        MovementGuaranteeModel.apply mustBe MovementGuaranteeModel(GuarantorArranger.GoodsOwner, Some(Seq(TraderModel(
           None,
           Some("name"),
           Some(AddressModel.fromUserAddress(testUserAddress)),
           Some("vat"),
           None
-        )))
+        ))))
       }
     }
   }


### PR DESCRIPTION
Honour the expected format which `emcs-tfe` is expecting