### PR TITLE
[ETFE-3254] Add logic to cater for when GurantorRequired should be forced to true

### DIFF
--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -19,7 +19,8 @@ package models.requests
 import models._
 import models.sections.info.DispatchPlace
 import models.sections.info.DispatchPlace.{GreatBritain, NorthernIreland}
-import pages.sections.info.DispatchPlacePage
+import models.sections.info.movementScenario.MovementType.UkToEu
+import pages.sections.info.{DestinationTypePage, DispatchPlacePage}
 import play.api.mvc.WrappedRequest
 import utils.Logging
 
@@ -47,4 +48,6 @@ case class DataRequest[A](request: UserRequest[A],
       logger.warn(s"[dispatchPlace] Invalid value for DISPATCH_PLACE: $value")
       None
   }
+
+  def isUkToEuMovement: Boolean = userAnswers.get(DestinationTypePage).map(_.movementType(this)).contains(UkToEu)
 }

--- a/app/viewmodels/checkAnswers/sections/guarantor/GuarantorRequiredSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/guarantor/GuarantorRequiredSummary.scala
@@ -18,7 +18,9 @@ package viewmodels.checkAnswers.sections.guarantor
 
 import models.CheckMode
 import models.requests.DataRequest
+import models.sections.journeyType.HowMovementTransported.FixedTransportInstallations
 import pages.sections.guarantor.GuarantorRequiredPage
+import pages.sections.journeyType.HowMovementTransportedPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
@@ -27,27 +29,37 @@ import viewmodels.implicits._
 object GuarantorRequiredSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
+    if(request.isUkToEuMovement) {
+      request.userAnswers.get(HowMovementTransportedPage) match {
+        case Some(FixedTransportInstallations) | None =>
+          Some(renderSummary)
+        case _ =>
+          None
+      }
+    } else {
+      Some(renderSummary)
+    }
+  }
+
+  private def renderSummary(implicit request: DataRequest[_], messages: Messages): SummaryListRow = {
 
     val value = request.userAnswers.get(GuarantorRequiredPage) match {
       case Some(answer) => if (answer) "site.yes" else "site.no"
       case None => "site.notProvided"
     }
 
-    Some(
-      SummaryListRowViewModel(
-        key = "guarantorRequired.checkYourAnswersLabel",
-        value = ValueViewModel(value),
-        actions = Seq(
-          ActionItemViewModel(
-            "site.change",
-            controllers.sections.guarantor.routes.GuarantorRequiredController.onPageLoad(request.ern, request.draftId, CheckMode).url,
-            "changeGuarantorRequired"
-          )
-            .withVisuallyHiddenText(messages("guarantorRequired.change.hidden"))
+    SummaryListRowViewModel(
+      key = "guarantorRequired.checkYourAnswersLabel",
+      value = ValueViewModel(value),
+      actions = Seq(
+        ActionItemViewModel(
+          "site.change",
+          controllers.sections.guarantor.routes.GuarantorRequiredController.onPageLoad(request.ern, request.draftId, CheckMode).url,
+          "changeGuarantorRequired"
         )
+          .withVisuallyHiddenText(messages("guarantorRequired.change.hidden"))
       )
     )
-
   }
 
 }

--- a/test-utils/fixtures/BaseFixtures.scala
+++ b/test-utils/fixtures/BaseFixtures.scala
@@ -38,6 +38,7 @@ trait BaseFixtures {
   val testInternalId: String = "internalId"
   val testErn: String = "XIRC123456789"
   val testNorthernIrelandErn = "XIWK123456789"
+  val testNIDutyPaidErn = "XIPA123456789"
   val testGreatBritainErn = "GBRC123456789"
   val testLrn: String = "1234567890"
   val testDraftId: String = "draftId"

--- a/test/controllers/sections/guarantor/GuarantorIndexControllerSpec.scala
+++ b/test/controllers/sections/guarantor/GuarantorIndexControllerSpec.scala
@@ -83,7 +83,7 @@ class GuarantorIndexControllerSpec extends SpecBase with MockUserAnswersService 
           }
         }
 
-        "when the Journey Type has not been answered as FixedTransportInstallations" - {
+        "when the Journey Type has been answered as FixedTransportInstallations" - {
           "must redirect to the guarantor required controller" in new Fixture(
             Some(emptyUserAnswers
               .set(DestinationTypePage, DirectDelivery)

--- a/test/controllers/sections/guarantor/GuarantorIndexControllerSpec.scala
+++ b/test/controllers/sections/guarantor/GuarantorIndexControllerSpec.scala
@@ -20,19 +20,25 @@ import base.SpecBase
 import controllers.actions.FakeDataRetrievalAction
 import mocks.services.MockUserAnswersService
 import models.sections.guarantor.GuarantorArranger.Consignor
+import models.sections.info.movementScenario.MovementScenario.DirectDelivery
+import models.sections.journeyType.HowMovementTransported.{FixedTransportInstallations, RoadTransport}
 import models.{NormalMode, UserAddress, UserAnswers}
 import navigation.FakeNavigators.FakeGuarantorNavigator
 import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.guarantor.{GuarantorArrangerPage, GuarantorRequiredPage}
+import pages.sections.info.DestinationTypePage
+import pages.sections.journeyType.HowMovementTransportedPage
 import play.api.http.Status.SEE_OTHER
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
+import scala.concurrent.Future
+
 class GuarantorIndexControllerSpec extends SpecBase with MockUserAnswersService {
 
-  class Fixture(optUserAnswers: Option[UserAnswers] = Some(emptyUserAnswers)) {
+  class Fixture(val optUserAnswers: Option[UserAnswers] = Some(emptyUserAnswers), ern: String = testErn) {
 
-    val request = FakeRequest(GET, controllers.sections.guarantor.routes.GuarantorIndexController.onPageLoad(testErn, testDraftId).url)
+    val request = FakeRequest(GET, routes.GuarantorIndexController.onPageLoad(ern, testDraftId).url)
 
     lazy val testController = new GuarantorIndexController(
       mockUserAnswersService,
@@ -58,15 +64,70 @@ class GuarantorIndexControllerSpec extends SpecBase with MockUserAnswersService 
         val result = testController.onPageLoad(testErn, testDraftId)(request)
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(controllers.sections.guarantor.routes.GuarantorCheckAnswersController.onPageLoad(testErn, testDraftId).url)
+        redirectLocation(result) mustBe Some(routes.GuarantorCheckAnswersController.onPageLoad(testErn, testDraftId).url)
       }
     }
-    "must redirect to the guarantor required controller" in new Fixture() {
-      val result = testController.onPageLoad(testErn, testDraftId)(request)
 
-      status(result) mustEqual SEE_OTHER
-      redirectLocation(result) mustBe Some(controllers.sections.guarantor.routes.GuarantorRequiredController.onPageLoad(testErn, testDraftId, NormalMode).url)
+    "when GuarantorSection is not complete" - {
+      "when the movement is UKtoEU" - {
+        "when the Journey Type has not been answered" - {
+          "must redirect to the guarantor required controller" in new Fixture(
+            Some(emptyUserAnswers.set(DestinationTypePage, DirectDelivery)),
+            testNorthernIrelandErn
+          ) {
+
+            val result = testController.onPageLoad(testNorthernIrelandErn, testDraftId)(request)
+
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result) mustBe Some(routes.GuarantorRequiredController.onPageLoad(testNorthernIrelandErn, testDraftId, NormalMode).url)
+          }
+        }
+
+        "when the Journey Type has not been answered as FixedTransportInstallations" - {
+          "must redirect to the guarantor required controller" in new Fixture(
+            Some(emptyUserAnswers
+              .set(DestinationTypePage, DirectDelivery)
+              .set(HowMovementTransportedPage, FixedTransportInstallations)
+            ),
+            testNorthernIrelandErn
+          ) {
+
+            val result = testController.onPageLoad(testNorthernIrelandErn, testDraftId)(request)
+
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result) mustBe Some(routes.GuarantorRequiredController.onPageLoad(testNorthernIrelandErn, testDraftId, NormalMode).url)
+          }
+        }
+
+        "when the Journey Type has not been answered as anything other than FixedTransportInstallations" - {
+          "must save the GurantorRequired page as True and redirect to the onward route of that page" in new Fixture(
+            Some(emptyUserAnswers
+              .set(DestinationTypePage, DirectDelivery)
+              .set(HowMovementTransportedPage, RoadTransport)
+            ),
+            testNorthernIrelandErn
+          ) {
+
+            val updatedAnswers = optUserAnswers.get.set(GuarantorRequiredPage, true)
+
+            MockUserAnswersService.set(updatedAnswers).returns(Future.successful(updatedAnswers))
+
+            val result = testController.onPageLoad(testNorthernIrelandErn, testDraftId)(request)
+
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result) mustBe Some(testOnwardRoute.url)
+          }
+        }
+      }
+      "when the movement is NOT UKtoEU" - {
+        "must redirect to the guarantor required controller" in new Fixture() {
+
+          val result = testController.onPageLoad(testErn, testDraftId)(request)
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.GuarantorRequiredController.onPageLoad(testErn, testDraftId, NormalMode).url)
+        }
+      }
     }
   }
-
 }

--- a/test/controllers/sections/guarantor/GuarantorIndexControllerSpec.scala
+++ b/test/controllers/sections/guarantor/GuarantorIndexControllerSpec.scala
@@ -99,7 +99,7 @@ class GuarantorIndexControllerSpec extends SpecBase with MockUserAnswersService 
           }
         }
 
-        "when the Journey Type has not been answered as anything other than FixedTransportInstallations" - {
+        "when the Journey Type has been answered as anything other than FixedTransportInstallations" - {
           "must save the GurantorRequired page as True and redirect to the onward route of that page" in new Fixture(
             Some(emptyUserAnswers
               .set(DestinationTypePage, DirectDelivery)

--- a/test/viewmodels/checkAnswers/sections/guarantor/GuarantorCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/guarantor/GuarantorCheckAnswersHelperSpec.scala
@@ -21,9 +21,13 @@ import fixtures.messages.sections.guarantor.GuarantorArrangerMessages.English
 import models.requests.DataRequest
 import models.sections.guarantor.GuarantorArranger
 import models.sections.guarantor.GuarantorArranger.{GoodsOwner, Transporter}
+import models.sections.info.movementScenario.MovementScenario.{DirectDelivery, GbTaxWarehouse}
+import models.sections.journeyType.HowMovementTransported.{FixedTransportInstallations, RoadTransport}
 import org.scalamock.scalatest.MockFactory
 import pages.sections.consignee.{ConsigneeAddressPage, ConsigneeBusinessNamePage}
 import pages.sections.guarantor._
+import pages.sections.info.DestinationTypePage
+import pages.sections.journeyType.HowMovementTransportedPage
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
 
@@ -34,49 +38,138 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
   }
 
   "summaryList" - {
-    GuarantorArranger.displayValues.foreach {
-      case value@(GoodsOwner | Transporter) =>
 
-        "must render five rows" - {
-          s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
-            implicit val request: DataRequest[_] = dataRequest(
-              FakeRequest(),
-              emptyUserAnswers
-                .set(GuarantorRequiredPage, true)
-                .set(GuarantorArrangerPage, value)
-                .set(GuarantorNamePage, "guarantor name")
-                .set(GuarantorVatPage, "gurantor123")
-                .set(GuarantorAddressPage, testUserAddress)
-            )
-            helper.summaryList()(request, msgs).rows.length mustBe 5
-          }
-        }
-      case value =>
-        "must render five rows" - {
-          s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
-            implicit val request: DataRequest[_] = dataRequest(
-              FakeRequest(),
-              emptyUserAnswers
-                .set(GuarantorRequiredPage, true)
-                .set(GuarantorArrangerPage, value)
-                .set(ConsigneeBusinessNamePage, s"$value name")
-                .set(ConsigneeAddressPage, testUserAddress)
-            )
-            helper.summaryList()(request, msgs).rows.length mustBe 5
-          }
-        }
-    }
+    "when movement is UKtoEU and JourneyType is FixedTransportInstallations (or JourneyType has not been answered yet)" - {
 
-    "must render one row" - {
-      "when no answers for the guarantor section" in new Test {
-        implicit val request: DataRequest[_] = dataRequest(
-          FakeRequest(),
-          emptyUserAnswers
-            .set(GuarantorRequiredPage, false)
-        )
-        helper.summaryList()(request, msgs).rows.length mustBe 1
+      GuarantorArranger.displayValues.foreach {
+        case value@(GoodsOwner | Transporter) =>
+
+          "must render five rows (GuarantorRequired is included)" - {
+            s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
+              implicit val request: DataRequest[_] = dataRequest(
+                FakeRequest(),
+                emptyUserAnswers
+                  .set(HowMovementTransportedPage, FixedTransportInstallations)
+                  .set(DestinationTypePage, DirectDelivery)
+                  .set(GuarantorRequiredPage, true)
+                  .set(GuarantorArrangerPage, value)
+                  .set(GuarantorNamePage, "guarantor name")
+                  .set(GuarantorVatPage, "gurantor123")
+                  .set(GuarantorAddressPage, testUserAddress),
+                testNorthernIrelandErn
+              )
+              helper.summaryList()(request, msgs).rows.length mustBe 5
+            }
+          }
+        case value =>
+          "must render five rows (GuarantorRequired is included)" - {
+            s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
+              implicit val request: DataRequest[_] = dataRequest(
+                FakeRequest(),
+                emptyUserAnswers
+                  .set(DestinationTypePage, DirectDelivery)
+                  .set(GuarantorRequiredPage, true)
+                  .set(GuarantorArrangerPage, value)
+                  .set(ConsigneeBusinessNamePage, s"$value name")
+                  .set(ConsigneeAddressPage, testUserAddress),
+                testNorthernIrelandErn
+              )
+              helper.summaryList()(request, msgs).rows.length mustBe 5
+            }
+          }
       }
     }
 
+    "when movement is UKtoEU and JourneyType is anything other than FixedTransportInstallations" - {
+
+      GuarantorArranger.displayValues.foreach {
+        case value@(GoodsOwner | Transporter) =>
+
+          "must render four rows (GuarantorRequired is excluded as it must be true and can't be changed)" - {
+            s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
+              implicit val request: DataRequest[_] = dataRequest(
+                FakeRequest(),
+                emptyUserAnswers
+                  .set(HowMovementTransportedPage, RoadTransport)
+                  .set(DestinationTypePage, DirectDelivery)
+                  .set(GuarantorRequiredPage, true)
+                  .set(GuarantorArrangerPage, value)
+                  .set(GuarantorNamePage, "guarantor name")
+                  .set(GuarantorVatPage, "gurantor123")
+                  .set(GuarantorAddressPage, testUserAddress),
+                testNorthernIrelandErn
+              )
+              helper.summaryList()(request, msgs).rows.length mustBe 4
+            }
+          }
+        case value =>
+          "must render four rows (GuarantorRequired is excluded as it must be true and can't be changed)" - {
+            s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
+              implicit val request: DataRequest[_] = dataRequest(
+                FakeRequest(),
+                emptyUserAnswers
+                  .set(HowMovementTransportedPage, RoadTransport)
+                  .set(DestinationTypePage, DirectDelivery)
+                  .set(GuarantorRequiredPage, true)
+                  .set(GuarantorArrangerPage, value)
+                  .set(ConsigneeBusinessNamePage, s"$value name")
+                  .set(ConsigneeAddressPage, testUserAddress),
+                testNorthernIrelandErn
+              )
+              helper.summaryList()(request, msgs).rows.length mustBe 4
+            }
+          }
+      }
+    }
+
+    "when movement is NOT UKtoEU" - {
+
+      GuarantorArranger.displayValues.foreach {
+        case value@(GoodsOwner | Transporter) =>
+
+          "must render five rows" - {
+            s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
+              implicit val request: DataRequest[_] = dataRequest(
+                FakeRequest(),
+                emptyUserAnswers
+                  .set(DestinationTypePage, GbTaxWarehouse)
+                  .set(GuarantorRequiredPage, true)
+                  .set(GuarantorArrangerPage, value)
+                  .set(GuarantorNamePage, "guarantor name")
+                  .set(GuarantorVatPage, "gurantor123")
+                  .set(GuarantorAddressPage, testUserAddress)
+              )
+              helper.summaryList()(request, msgs).rows.length mustBe 5
+            }
+          }
+        case value =>
+          "must render five rows" - {
+            s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
+              implicit val request: DataRequest[_] = dataRequest(
+                FakeRequest(),
+                emptyUserAnswers
+                  .set(DestinationTypePage, GbTaxWarehouse)
+                  .set(GuarantorRequiredPage, true)
+                  .set(GuarantorArrangerPage, value)
+                  .set(ConsigneeBusinessNamePage, s"$value name")
+                  .set(ConsigneeAddressPage, testUserAddress)
+              )
+              helper.summaryList()(request, msgs).rows.length mustBe 5
+            }
+          }
+      }
+
+      "must render one row" - {
+        "when no answers for the guarantor section" in new Test {
+          implicit val request: DataRequest[_] = dataRequest(
+            FakeRequest(),
+            emptyUserAnswers
+              .set(DestinationTypePage, GbTaxWarehouse)
+              .set(GuarantorRequiredPage, false)
+          )
+          helper.summaryList()(request, msgs).rows.length mustBe 1
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Demoed to Tom and he's happy with the flow change now for EUtoUK movements - a User should never be able to get into an invalid scenario now. There's going to be a separate content alignment ticket to add some more information to the users to help them understands what's going on and that will be played separately.