### PR TITLE
ETFE-3435 Accessibility fix - page should contain a level one heading

### DIFF
--- a/app/views/sections/items/ItemGeographicalIndicationChoiceView.scala.html
+++ b/app/views/sections/items/ItemGeographicalIndicationChoiceView.scala.html
@@ -45,7 +45,7 @@
       @govukRadios(
         RadiosViewModel(
           field = form("value"),
-          legend = LegendViewModel(Text(messages("itemGeographicalIndicationChoice.legend", goodsType.toSingularOutput()))).withCssClass(LegendSize.Large.toString),
+          legend = LegendViewModel(Text(messages("itemGeographicalIndicationChoice.legend", goodsType.toSingularOutput()))).asPageHeading(LegendSize.Large),
           items = ItemGeographicalIndicationType.options
         ).withHint(HintViewModel(messages("itemGeographicalIndicationChoice.hint")))
       )


### PR DESCRIPTION
Before
<img width="2005" alt="image" src="https://github.com/hmrc/emcs-tfe-create-movement-frontend/assets/11269301/6c5f7e71-3c1a-46d3-ab33-bf29167c0384">


After
<img width="1998" alt="image" src="https://github.com/hmrc/emcs-tfe-create-movement-frontend/assets/11269301/658e6607-c938-4975-bcd0-d2b95df150a0">
