### PR TITLE
[ETFE-3548] - Wipe submission (704) errors when EPC/CN code changed for item

### DIFF
--- a/app/controllers/sections/items/ItemExciseProductCodeController.scala
+++ b/app/controllers/sections/items/ItemExciseProductCodeController.scala
@@ -80,7 +80,7 @@ class ItemExciseProductCodeController @Inject()(
                 val updatedUserAnswers = cleanseUserAnswersIfValueHasChanged(
                   page = ItemExciseProductCodePage(idx),
                   newAnswer = value,
-                  cleansingFunction = request.userAnswers.resetIndexedSection(ItemsSectionItem(idx), idx)
+                  cleansingFunction = updateItemSubmissionFailureIndexes(idx, request.userAnswers.resetIndexedSection(ItemsSectionItem(idx), idx))
                 )
                 saveAndRedirect(ItemExciseProductCodePage(idx), value, updatedUserAnswers, mode)
               }

--- a/test/controllers/sections/items/BaseItemsNavigationControllerSpec.scala
+++ b/test/controllers/sections/items/BaseItemsNavigationControllerSpec.scala
@@ -17,9 +17,9 @@
 package controllers.sections.items
 
 import base.SpecBase
-import fixtures.ItemFixtures
+import fixtures.{ItemFixtures, MovementSubmissionFailureFixtures}
 import mocks.services.{MockGetCnCodeInformationService, MockUserAnswersService}
-import models.UserAnswers
+import models.{Index, UserAnswers}
 import models.requests.DataRequest
 import models.response.referenceData.{BulkPackagingType, CnCodeInformation, ItemPackaging}
 import models.sections.items.ItemBulkPackagingCode.BulkSolidPowders
@@ -36,7 +36,8 @@ import scala.concurrent.Future
 class BaseItemsNavigationControllerSpec extends SpecBase
   with MockGetCnCodeInformationService
   with MockUserAnswersService
-  with ItemFixtures {
+  with ItemFixtures
+  with MovementSubmissionFailureFixtures {
 
   class Test(val userAnswers: UserAnswers) {
     implicit val request: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
@@ -109,6 +110,119 @@ class BaseItemsNavigationControllerSpec extends SpecBase
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe routes.ItemsIndexController.onPageLoad(request.ern, request.draftId).url
+      }
+    }
+  }
+
+  //scalastyle:off
+  ".updateItemSubmissionFailureIndexes" - {
+
+    "when multiple errors for multiple items exists" - {
+
+      val userAnswersWithFailures = emptyUserAnswers.copy(submissionFailures = Seq(
+        movementSubmissionFailure,
+        itemQuantityFailure(1),
+        itemQuantityFailure(4),
+        itemQuantityFailure(10),
+        movementSubmissionFailure,
+        itemQuantityFailure(20),
+        itemQuantityFailure(11)
+      ))
+
+      "when removing an item at the start (first item with error)" - {
+
+        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(userAnswersWithFailures) {
+
+          val result = controller.updateItemSubmissionFailureIndexes(Index(0), userAnswersWithFailures)
+
+          result.submissionFailures mustBe Seq(
+            movementSubmissionFailure,
+            itemQuantityFailure(3),
+            itemQuantityFailure(9),
+            movementSubmissionFailure,
+            itemQuantityFailure(19),
+            itemQuantityFailure(10)
+          )
+        }
+      }
+
+      "when removing an item at a mid-point" - {
+
+        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(userAnswersWithFailures) {
+
+          val result = controller.updateItemSubmissionFailureIndexes(Index(3), userAnswersWithFailures)
+
+          result.submissionFailures mustBe Seq(
+            movementSubmissionFailure,
+            itemQuantityFailure(1),
+            itemQuantityFailure(9),
+            movementSubmissionFailure,
+            itemQuantityFailure(19),
+            itemQuantityFailure(10)
+          )
+        }
+      }
+
+      "when removing an item at the end (last item with error)" - {
+
+        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(userAnswersWithFailures) {
+
+          val result = controller.updateItemSubmissionFailureIndexes(Index(19), userAnswersWithFailures)
+
+          result.submissionFailures mustBe Seq(
+            movementSubmissionFailure,
+            itemQuantityFailure(1),
+            itemQuantityFailure(4),
+            itemQuantityFailure(10),
+            movementSubmissionFailure,
+            itemQuantityFailure(11)
+          )
+        }
+      }
+
+      "when removing an item that doesn't have an error against it" - {
+
+        "should update all subsequent XPath for ErrorLocations to synchronise them with the new array order" in new Test(userAnswersWithFailures) {
+
+          val result = controller.updateItemSubmissionFailureIndexes(Index(15), userAnswersWithFailures)
+
+          result.submissionFailures mustBe Seq(
+            movementSubmissionFailure,
+            itemQuantityFailure(1),
+            itemQuantityFailure(4),
+            itemQuantityFailure(10),
+            movementSubmissionFailure,
+            itemQuantityFailure(19),
+            itemQuantityFailure(11)
+          )
+        }
+      }
+
+      "when removing an item and not submission failures exist for any items" - {
+
+        val userAnswersWithFailures = emptyUserAnswers.copy(submissionFailures = Seq(movementSubmissionFailure))
+
+        "should return the submission failures unaffected" in new Test(userAnswersWithFailures) {
+
+          val result = controller.updateItemSubmissionFailureIndexes(Index(15), userAnswersWithFailures)
+
+          result.submissionFailures mustBe Seq(movementSubmissionFailure)
+        }
+      }
+
+      "when removing an item before another item" - {
+
+        val userAnswersWithFailures = emptyUserAnswers.copy(submissionFailures = Seq(
+          itemQuantityFailure(1).copy(originalAttributeValue = Some("1")),
+          itemQuantityFailure(2)
+        ))
+
+        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(userAnswersWithFailures) {
+
+          val result = controller.updateItemSubmissionFailureIndexes(Index(0), userAnswersWithFailures)
+
+          result.submissionFailures mustBe Seq(itemQuantityFailure(1))
+        }
       }
     }
   }

--- a/test/controllers/sections/items/ItemExciseProductCodeControllerSpec.scala
+++ b/test/controllers/sections/items/ItemExciseProductCodeControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers.sections.items
 
 import base.SpecBase
 import controllers.actions.FakeDataRetrievalAction
-import fixtures.ItemFixtures
+import fixtures.{ItemFixtures, MovementSubmissionFailureFixtures}
 import forms.sections.items.ItemExciseProductCodeFormProvider
 import mocks.services.{MockGetExciseProductCodesService, MockUserAnswersService}
 import models.{ExciseProductCode, NormalMode, UserAnswers}
@@ -37,7 +37,8 @@ import scala.concurrent.Future
 class ItemExciseProductCodeControllerSpec extends SpecBase
   with MockUserAnswersService
   with MockGetExciseProductCodesService
-  with ItemFixtures {
+  with ItemFixtures
+  with MovementSubmissionFailureFixtures {
 
   val action: Call = controllers.sections.items.routes.ItemExciseProductCodeController.onSubmit(testErn, testDraftId, testIndex1, NormalMode)
 
@@ -155,10 +156,12 @@ class ItemExciseProductCodeControllerSpec extends SpecBase
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual testOnwardRoute.url
         }
-        "and only clear down the current item's answers when the previous answer is different to the new answer" in new Fixture(Some(
+        "and only clear down the current item's answers when the previous answer is different to the new answer" +
+          " (and remove any 704 errors)" in new Fixture(Some(
           emptyUserAnswers
             .set(ItemExciseProductCodePage(testIndex1), testEpcTobacco)
             .set(ItemExciseProductCodePage(testIndex2), testExciseProductCodeB000.code)
+            .copy(submissionFailures = Seq(itemQuantityFailure(1), itemQuantityFailure(2).copy(originalAttributeValue = Some("UPDATED")), movementSubmissionFailure))
         )) {
           MockGetExciseProductCodesService.getExciseProductCodes().returns(Future.successful(sampleEPCs))
 
@@ -166,10 +169,12 @@ class ItemExciseProductCodeControllerSpec extends SpecBase
             emptyUserAnswers
               .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
               .set(ItemExciseProductCodePage(testIndex2), testExciseProductCodeB000.code)
+              .copy(submissionFailures = Seq(itemQuantityFailure(1).copy(originalAttributeValue = Some("UPDATED")), movementSubmissionFailure))
           ).returns(Future.successful(
             emptyUserAnswers
               .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
               .set(ItemExciseProductCodePage(testIndex2), testExciseProductCodeB000.code)
+              .copy(submissionFailures = Seq(itemQuantityFailure(1).copy(originalAttributeValue = Some("UPDATED")), movementSubmissionFailure))
           ))
 
           val result: Future[Result] =

--- a/test/controllers/sections/items/ItemRemoveItemControllerSpec.scala
+++ b/test/controllers/sections/items/ItemRemoveItemControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.FakeDataRetrievalAction
 import fixtures.{ItemFixtures, MovementSubmissionFailureFixtures}
 import forms.sections.items.ItemRemoveItemFormProvider
 import mocks.services.MockUserAnswersService
-import models.{Index, UserAnswers}
+import models.UserAnswers
 import navigation.FakeNavigators.FakeItemsNavigator
 import pages.sections.items.ItemExciseProductCodePage
 import play.api.mvc.{AnyContentAsEmpty, Call}
@@ -137,118 +137,6 @@ class ItemRemoveItemControllerSpec extends SpecBase with MockUserAnswersService 
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
-    }
-  }
-
-  ".updateItemSubmissionFailureIndexes" - {
-
-    "when multiple errors for multiple items exists" - {
-
-      val userAnswersWithFailures = emptyUserAnswers.copy(submissionFailures = Seq(
-        movementSubmissionFailure,
-        itemQuantityFailure(1),
-        itemQuantityFailure(4),
-        itemQuantityFailure(10),
-        movementSubmissionFailure,
-        itemQuantityFailure(20),
-        itemQuantityFailure(11)
-      ))
-
-      "when removing an item at the start (first item with error)" - {
-
-        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(Some(userAnswersWithFailures)) {
-
-          val result = controller.updateItemSubmissionFailureIndexes(Index(0), userAnswersWithFailures)
-
-          result.submissionFailures mustBe Seq(
-            movementSubmissionFailure,
-            itemQuantityFailure(3),
-            itemQuantityFailure(9),
-            movementSubmissionFailure,
-            itemQuantityFailure(19),
-            itemQuantityFailure(10)
-          )
-        }
-      }
-
-      "when removing an item at a mid-point" - {
-
-        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(Some(userAnswersWithFailures)) {
-
-          val result = controller.updateItemSubmissionFailureIndexes(Index(3), userAnswersWithFailures)
-
-          result.submissionFailures mustBe Seq(
-            movementSubmissionFailure,
-            itemQuantityFailure(1),
-            itemQuantityFailure(9),
-            movementSubmissionFailure,
-            itemQuantityFailure(19),
-            itemQuantityFailure(10)
-          )
-        }
-      }
-
-      "when removing an item at the end (last item with error)" - {
-
-        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(Some(userAnswersWithFailures)) {
-
-          val result = controller.updateItemSubmissionFailureIndexes(Index(19), userAnswersWithFailures)
-
-          result.submissionFailures mustBe Seq(
-            movementSubmissionFailure,
-            itemQuantityFailure(1),
-            itemQuantityFailure(4),
-            itemQuantityFailure(10),
-            movementSubmissionFailure,
-            itemQuantityFailure(11)
-          )
-        }
-      }
-
-      "when removing an item that doesn't have an error against it" - {
-
-        "should update all subsequent XPath for ErrorLocations to synchronise them with the new array order" in new Test(Some(userAnswersWithFailures)) {
-
-          val result = controller.updateItemSubmissionFailureIndexes(Index(15), userAnswersWithFailures)
-
-          result.submissionFailures mustBe Seq(
-            movementSubmissionFailure,
-            itemQuantityFailure(1),
-            itemQuantityFailure(4),
-            itemQuantityFailure(10),
-            movementSubmissionFailure,
-            itemQuantityFailure(19),
-            itemQuantityFailure(11)
-          )
-        }
-      }
-
-      "when removing an item and not submission failures exist for any items" - {
-
-        val userAnswersWithFailures = emptyUserAnswers.copy(submissionFailures = Seq(movementSubmissionFailure))
-
-        "should return the submission failures unaffected" in new Test(Some(userAnswersWithFailures)) {
-
-          val result = controller.updateItemSubmissionFailureIndexes(Index(15), userAnswersWithFailures)
-
-          result.submissionFailures mustBe Seq(movementSubmissionFailure)
-        }
-      }
-
-      "when removing an item before another item" - {
-
-        val userAnswersWithFailures = emptyUserAnswers.copy(submissionFailures = Seq(
-          itemQuantityFailure(1).copy(originalAttributeValue = Some("1")),
-          itemQuantityFailure(2)
-        ))
-
-        "should remove the item failure AND reindex XPath for ErrorLocations to synchronise them with the new array order" in new Test(Some(userAnswersWithFailures)) {
-
-          val result = controller.updateItemSubmissionFailureIndexes(Index(0), userAnswersWithFailures)
-
-          result.submissionFailures mustBe Seq(itemQuantityFailure(1))
-        }
-      }
     }
   }
 }

--- a/test/mocks/services/MockUserAnswersService.scala
+++ b/test/mocks/services/MockUserAnswersService.scala
@@ -40,7 +40,8 @@ trait MockUserAnswersService extends MockFactory {
         .expects(where { (actualAnswers, _) =>
           actualAnswers.ern == userAnswers.ern &&
             //Declaration page stores a LocalDateTime which can't be asserted against reliably
-            actualAnswers.data - DeclarationPage == userAnswers.data - DeclarationPage
+            actualAnswers.data - DeclarationPage == userAnswers.data - DeclarationPage &&
+            actualAnswers.submissionFailures == userAnswers.submissionFailures
         })
 
     def set(): CallHandler2[UserAnswers, HeaderCarrier, Future[UserAnswers]] =

--- a/test/views/sections/importInformation/ImportCustomsOfficeCodeViewSpec.scala
+++ b/test/views/sections/importInformation/ImportCustomsOfficeCodeViewSpec.scala
@@ -24,8 +24,6 @@ import models.requests.DataRequest
 import models.{GreatBritainRegisteredConsignor, NorthernIrelandRegisteredConsignor, UserAnswers, UserType}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import pages.sections.importInformation.ImportCustomsOfficeCodePage
-import play.api.data.FormError
 import play.api.i18n.{Lang, Messages}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest


### PR DESCRIPTION
Ensures, when an item in error has changed (i.e. EPC has been changed), that we clear any errors (704) related to that item