### PR TITLE
[ETFE-3664] Updating the GuarantorVat controller and view

### DIFF
--- a/app/controllers/sections/transportArranger/TransportArrangerVatController.scala
+++ b/app/controllers/sections/transportArranger/TransportArrangerVatController.scala
@@ -19,10 +19,10 @@ package controllers.sections.transportArranger
 import controllers.BaseNavigationController
 import controllers.actions._
 import forms.sections.transportArranger.TransportArrangerVatFormProvider
-import forms.sections.transportArranger.TransportArrangerVatFormProvider.{transportArrangerVatNumberField, transportArrangerVatNumberRequired}
-import models.Mode
+import forms.sections.transportArranger.TransportArrangerVatFormProvider.{vatNumberField, vatNumberRequired}
+import models.{Mode, VatNumberModel}
 import models.requests.DataRequest
-import models.sections.transportArranger.{TransportArranger, TransportArrangerVatModel}
+import models.sections.transportArranger.TransportArranger
 import navigation.TransportArrangerNavigator
 import pages.sections.transportArranger.{TransportArrangerPage, TransportArrangerVatPage}
 import play.api.data.Form
@@ -77,16 +77,16 @@ class TransportArrangerVatController @Inject()(
         arranger
       )))
 
-  private def handleSubmittedForm(transportArrangerVatModel: TransportArrangerVatModel, arranger: TransportArranger, mode: Mode)
+  private def handleSubmittedForm(transportArrangerVatModel: VatNumberModel, arranger: TransportArranger, mode: Mode)
                                  (implicit request: DataRequest[_], messages: Messages): Future[Result] = {
 
-    if (transportArrangerVatModel.hasTransportArrangerVatNumber && transportArrangerVatModel.transportArrangerVatNumber.isEmpty) {
+    if (transportArrangerVatModel.hasVatNumber && transportArrangerVatModel.vatNumber.isEmpty) {
       renderView(
         status = BadRequest,
         form =
           formProvider(arranger)
             .fill(transportArrangerVatModel)
-            .withError(transportArrangerVatNumberField, messages(transportArrangerVatNumberRequired)),
+            .withError(vatNumberField, messages(vatNumberRequired)),
         arranger = arranger,
         mode = mode
       )

--- a/app/forms/sections/guarantor/GuarantorVatFormProvider.scala
+++ b/app/forms/sections/guarantor/GuarantorVatFormProvider.scala
@@ -18,7 +18,7 @@ package forms.sections.guarantor
 
 import forms.ONLY_ALPHANUMERIC_REGEX
 import forms.mappings.Mappings
-import forms.sections.guarantor.GuarantorVatFormProvider.{hasVatNumberField, vatNumberField, vatNumberRequired}
+import forms.sections.guarantor.GuarantorVatFormProvider._
 import models.VatNumberModel
 import models.sections.guarantor.GuarantorArranger
 import play.api.data.Form
@@ -32,17 +32,14 @@ class GuarantorVatFormProvider @Inject() extends Mappings {
   def apply(guarantorArranger: GuarantorArranger): Form[VatNumberModel] =
     Form(
       mapping(
-        hasVatNumberField -> boolean(s"guarantorVat.$guarantorArranger.error.radio.required"),
+        hasVatNumberField -> boolean(vatRadioRequired(guarantorArranger)),
         vatNumberField -> ConditionalMappings.mandatoryIfTrue(hasVatNumberField,
           text(vatNumberRequired)
-            .verifying(maxLength(14, "guarantorVat.error.input.length"))
+            .verifying(maxLength(14, vatNumberLength))
             .transform[String](_.replace("-", "").replace(" ", ""), identity)
-            .verifying(regexp(ONLY_ALPHANUMERIC_REGEX, "guarantorVat.error.input.alphanumeric"))
+            .verifying(regexp(ONLY_ALPHANUMERIC_REGEX, vatNumberAlphanumeric))
         )
       )(VatNumberModel.apply)(VatNumberModel.unapply)
-        .transform[VatNumberModel](
-          model => if (!model.hasVatNumber) model.copy(vatNumber = None) else model, identity
-        )
     )
 }
 
@@ -50,5 +47,8 @@ object GuarantorVatFormProvider {
   val hasVatNumberField = "hasVatNumber"
   val vatNumberField = "vatNumber"
 
+  val vatRadioRequired: GuarantorArranger => String = arranger =>  s"guarantorVat.$arranger.error.radio.required"
   val vatNumberRequired = "guarantorVat.error.input.required"
+  val vatNumberLength = "guarantorVat.error.input.length"
+  val vatNumberAlphanumeric = "guarantorVat.error.input.alphanumeric"
 }

--- a/app/forms/sections/transportArranger/TransportArrangerVatFormProvider.scala
+++ b/app/forms/sections/transportArranger/TransportArrangerVatFormProvider.scala
@@ -18,8 +18,9 @@ package forms.sections.transportArranger
 
 import forms.ONLY_ALPHANUMERIC_REGEX
 import forms.mappings.Mappings
-import forms.sections.transportArranger.TransportArrangerVatFormProvider.{hasVatNumberField, transportArrangerVatNumberField}
-import models.sections.transportArranger.{TransportArranger, TransportArrangerVatModel}
+import forms.sections.transportArranger.TransportArrangerVatFormProvider.{hasVatNumberField, vatNumberField}
+import models.VatNumberModel
+import models.sections.transportArranger.TransportArranger
 import play.api.data.Form
 import play.api.data.Forms.{mapping, optional, text => playText}
 
@@ -27,27 +28,27 @@ import javax.inject.Inject
 
 class TransportArrangerVatFormProvider @Inject() extends Mappings {
 
-  def apply(transportArranger: TransportArranger): Form[TransportArrangerVatModel] =
+  def apply(transportArranger: TransportArranger): Form[VatNumberModel] =
     Form(
       mapping(
         hasVatNumberField -> boolean(s"transportArrangerVat.error.radio.$transportArranger.required"),
-        transportArrangerVatNumberField -> optional(
+        vatNumberField -> optional(
           playText()
             .verifying(maxLength(14, "transportArrangerVat.error.length"))
             .transform[String](_.replace("-", "").replace(" ", ""), identity)
             .verifying(regexp(ONLY_ALPHANUMERIC_REGEX, "transportArrangerVat.error.alphanumeric"))
         )
-      )(TransportArrangerVatModel.apply)(TransportArrangerVatModel.unapply)
-        .transform[TransportArrangerVatModel](
-          model => if(!model.hasTransportArrangerVatNumber) model.copy(transportArrangerVatNumber = None) else model, identity
+      )(VatNumberModel.apply)(VatNumberModel.unapply)
+        .transform[VatNumberModel](
+          model => if(!model.hasVatNumber) model.copy(vatNumber = None) else model, identity
         )
     )
 }
 
 object TransportArrangerVatFormProvider {
 
-  val hasVatNumberField = "hasTransportArrangerVatNumber"
-  val transportArrangerVatNumberField = "transportArrangerVatNumber"
+  val hasVatNumberField = "hasVatNumber"
+  val vatNumberField = "vatNumber"
 
-  val transportArrangerVatNumberRequired = "transportArrangerVat.error.input.required"
+  val vatNumberRequired = "transportArrangerVat.error.input.required"
 }

--- a/app/models/VatNumberModel.scala
+++ b/app/models/VatNumberModel.scala
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package models.sections.transportArranger
+package models
 
 import play.api.libs.json.{Format, Json}
 
-case class TransportArrangerVatModel(
-                                      hasTransportArrangerVatNumber: Boolean,
-                                      transportArrangerVatNumber: Option[String]
-                                    )
+case class VatNumberModel(hasVatNumber: Boolean,
+                          vatNumber: Option[String])
 
-object TransportArrangerVatModel {
+object VatNumberModel {
 
-  implicit val format: Format[TransportArrangerVatModel] = Json.format[TransportArrangerVatModel]
+  implicit val format: Format[VatNumberModel] = Json.format[VatNumberModel]
 }

--- a/app/models/submitCreateMovement/TraderModel.scala
+++ b/app/models/submitCreateMovement/TraderModel.scala
@@ -162,10 +162,10 @@ object TraderModel extends ModelConstructorHelpers {
         traderName = Some(mandatoryPage(TransportArrangerNamePage)),
         address = Some(AddressModel.fromUserAddress(mandatoryPage(TransportArrangerAddressPage))),
         /*
-          On the TransportArrangerVatPage when the user clicks No we set the `transportArrangerVatNumber` to None
+          On the TransportArrangerVatPage when the user clicks No we set the `vatNumber` to None
           We need to default this to NONGBVAT hence the getOrElse.
          */
-        vatNumber = Some(mandatoryPage(TransportArrangerVatPage).transportArrangerVatNumber.getOrElse(NONGBVAT)),
+        vatNumber = Some(mandatoryPage(TransportArrangerVatPage).vatNumber.getOrElse(NONGBVAT)),
         eoriNumber = None
       ))
     }
@@ -191,7 +191,7 @@ object TraderModel extends ModelConstructorHelpers {
         traderExciseNumber = None,
         traderName = Some(mandatoryPage(GuarantorNamePage)),
         address = Some(AddressModel.fromUserAddress(mandatoryPage(GuarantorAddressPage))),
-        vatNumber = Some(mandatoryPage(GuarantorVatPage)),
+        vatNumber = Some(mandatoryPage(GuarantorVatPage).vatNumber.getOrElse(NONGBVAT)),
         eoriNumber = None
       ))
     }

--- a/app/pages/sections/guarantor/GuarantorVatPage.scala
+++ b/app/pages/sections/guarantor/GuarantorVatPage.scala
@@ -16,10 +16,11 @@
 
 package pages.sections.guarantor
 
+import models.VatNumberModel
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object GuarantorVatPage extends QuestionPage[String] {
+case object GuarantorVatPage extends QuestionPage[VatNumberModel] {
   override val toString: String = "guarantorVat"
   override val path: JsPath = GuarantorSection.path \ toString
 }

--- a/app/pages/sections/transportArranger/TransportArrangerVatPage.scala
+++ b/app/pages/sections/transportArranger/TransportArrangerVatPage.scala
@@ -16,11 +16,11 @@
 
 package pages.sections.transportArranger
 
-import models.sections.transportArranger.TransportArrangerVatModel
+import models.VatNumberModel
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object TransportArrangerVatPage extends QuestionPage[TransportArrangerVatModel] {
+case object TransportArrangerVatPage extends QuestionPage[VatNumberModel] {
   override val toString: String = "vat"
   override val path: JsPath = TransportArrangerSection.path \ toString
 }

--- a/app/viewmodels/checkAnswers/sections/guarantor/GuarantorCheckAnswersHelper.scala
+++ b/app/viewmodels/checkAnswers/sections/guarantor/GuarantorCheckAnswersHelper.scala
@@ -32,7 +32,7 @@ class GuarantorCheckAnswersHelper @Inject()() {
         GuarantorRequiredSummary.row,
         GuarantorArrangerSummary.row,
         GuarantorNameSummary.row,
-        GuarantorErnVatEoriSummary.row,
+        GuarantorErnVatEoriSummary.rows,
         GuarantorAddressSummary.row
       ).flatten
     ).withCssClass("govuk-!-margin-bottom-9")

--- a/app/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatChoiceSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatChoiceSummary.scala
@@ -32,7 +32,7 @@ object TransportArrangerVatChoiceSummary {
     request.userAnswers.get(TransportArrangerPage) match {
       case Some(GoodsOwner | Other) =>
         request.userAnswers.get(TransportArrangerVatPage).map { answer =>
-          val value = if(answer.hasTransportArrangerVatNumber) "site.yes" else "site.no"
+          val value = if(answer.hasVatNumber) "site.yes" else "site.no"
           SummaryListRowViewModel(
             key = "transportArrangerVat.checkYourAnswers.choice.label",
             value = ValueViewModel(value),

--- a/app/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatSummary.scala
@@ -33,10 +33,10 @@ object TransportArrangerVatSummary {
     request.userAnswers.get(TransportArrangerPage) match {
       case Some(GoodsOwner | Other) =>
         request.userAnswers.get(TransportArrangerVatPage).flatMap { answer =>
-          Option.when(answer.transportArrangerVatNumber.isDefined) {
+          Option.when(answer.vatNumber.isDefined) {
             SummaryListRowViewModel(
               key = "transportArrangerVat.checkYourAnswers.input.label",
-              value = ValueViewModel(HtmlFormat.escape(answer.transportArrangerVatNumber.get).toString()),
+              value = ValueViewModel(HtmlFormat.escape(answer.vatNumber.get).toString()),
               actions = Seq(
                 ActionItemViewModel(
                   content = "site.change",

--- a/app/views/sections/guarantor/GuarantorVatView.scala.html
+++ b/app/views/sections/guarantor/GuarantorVatView.scala.html
@@ -18,19 +18,22 @@
 @import models.sections.guarantor.GuarantorArranger
 @import viewmodels.InputWidth._
 @import viewmodels.LabelSize
+@import forms.sections.guarantor.GuarantorVatFormProvider
+@import viewmodels.LegendSize
+@import viewmodels.InputWidth
 
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
+    govukRadios: GovukRadios,
     govukButton: GovukButton,
     h2: components.h2,
     continueOrExit: components.continueOrExit,
     link: components.link,
     p: components.p
 )
-
 
 @(form: Form[_], guarantorArranger: GuarantorArranger, mode: Mode)(implicit request: DataRequest[_], messages: Messages)
 
@@ -43,24 +46,35 @@
         }
 
         @h2(messages("guarantor.subHeading"), "govuk-caption-xl", hiddenContent = Some(messages("subHeading.hidden")))
-        @govukInput(
-            InputViewModel(
-                field = form("value"),
-                label = LabelViewModel(Text(messages(s"guarantorVat.$guarantorArranger.heading"))).asPageHeading(LabelSize.Large)
-            )
-            .withWidth(Full)
-            .withHint(HintViewModel(Text(messages("guarantorVat.hint"))))
+        @govukRadios(
+            RadiosViewModel.apply(
+                field = form(GuarantorVatFormProvider.hasVatNumberField),
+                items = Seq(
+                    RadioItem(
+                        id      = Some(form(GuarantorVatFormProvider.hasVatNumberField).id),
+                        value   = Some("true"),
+                        content = Text(messages("site.yes")),
+                        conditionalHtml = Some(vatRegistrationNumber)
+                    ),
+                    RadioItem(
+                        id      = Some(s"${form(GuarantorVatFormProvider.hasVatNumberField).id}-no"),
+                        value   = Some("false"),
+                        content = Text(messages("site.no"))
+                    )
+                ),
+                legend = LegendViewModel(Text(messages(s"guarantorVat.$guarantorArranger.heading"))).asPageHeading(LegendSize.Large)
+            ).withHint(HintViewModel(content = Text(messages("guarantorVat.hint"))))
         )
-
-        @p() {
-            @link(
-                controllers.sections.guarantor.routes.GuarantorVatController.onNonGbVAT(request.ern, request.draftId, mode).url,
-                s"guarantorVat.$guarantorArranger.notUkVatLink"
-            )
-        }
 
         @continueOrExit()
     }
+}
+
+@vatRegistrationNumber = {
+    @govukInput(InputViewModel.apply(
+        form(GuarantorVatFormProvider.vatNumberField),
+        LabelViewModel(Text(messages("guarantorVat.input.label")))
+    ).withWidth(InputWidth.TwoThirds))
 }
 
 @{

--- a/app/views/sections/guarantor/GuarantorVatView.scala.html
+++ b/app/views/sections/guarantor/GuarantorVatView.scala.html
@@ -14,13 +14,10 @@
  * limitations under the License.
  *@
 
+@import forms.sections.guarantor.GuarantorVatFormProvider
 @import models.requests.DataRequest
 @import models.sections.guarantor.GuarantorArranger
-@import viewmodels.InputWidth._
-@import viewmodels.LabelSize
-@import forms.sections.guarantor.GuarantorVatFormProvider
-@import viewmodels.LegendSize
-@import viewmodels.InputWidth
+@import viewmodels.{InputWidth, LegendSize}
 
 @this(
     layout: templates.Layout,
@@ -30,9 +27,7 @@
     govukRadios: GovukRadios,
     govukButton: GovukButton,
     h2: components.h2,
-    continueOrExit: components.continueOrExit,
-    link: components.link,
-    p: components.p
+    continueOrExit: components.continueOrExit
 )
 
 @(form: Form[_], guarantorArranger: GuarantorArranger, mode: Mode)(implicit request: DataRequest[_], messages: Messages)

--- a/app/views/sections/transportArranger/TransportArrangerVatView.scala.html
+++ b/app/views/sections/transportArranger/TransportArrangerVatView.scala.html
@@ -67,7 +67,7 @@
 
 @vatRegistrationNumber = {
   @govukInput(InputViewModel.apply(
-    form(TransportArrangerVatFormProvider.transportArrangerVatNumberField),
+    form(TransportArrangerVatFormProvider.vatNumberField),
     LabelViewModel(Text(messages("transportArrangerVat.input.label")))
   ).withWidth(InputWidth.TwoThirds))
 }

--- a/conf/guarantor.routes
+++ b/conf/guarantor.routes
@@ -19,8 +19,6 @@ GET         /trader/:ern/draft/:draftId/guarantor/vat                          c
 POST        /trader/:ern/draft/:draftId/guarantor/vat                          controllers.sections.guarantor.GuarantorVatController.onSubmit(ern: String, draftId: String, mode: Mode = NormalMode)
 GET         /trader/:ern/draft/:draftId/guarantor/vat/change                   controllers.sections.guarantor.GuarantorVatController.onPageLoad(ern: String, draftId: String, mode: Mode = CheckMode)
 POST        /trader/:ern/draft/:draftId/guarantor/vat/change                   controllers.sections.guarantor.GuarantorVatController.onSubmit(ern: String, draftId: String, mode: Mode = CheckMode)
-GET         /trader/:ern/draft/:draftId/guarantor/vat/non-gb-vat               controllers.sections.guarantor.GuarantorVatController.onNonGbVAT(ern: String, draftId: String, mode: Mode = NormalMode)
-GET         /trader/:ern/draft/:draftId/guarantor/vat/non-gb-vat/change        controllers.sections.guarantor.GuarantorVatController.onNonGbVAT(ern: String, draftId: String, mode: Mode = CheckMode)
 
 GET         /trader/:ern/draft/:draftId/guarantor/address                      controllers.sections.guarantor.GuarantorAddressController.onPageLoad(ern: String, draftId: String, mode: Mode = NormalMode)
 POST        /trader/:ern/draft/:draftId/guarantor/address                      controllers.sections.guarantor.GuarantorAddressController.onSubmit(ern: String, draftId: String, mode: Mode = NormalMode)

--- a/conf/messages
+++ b/conf/messages
@@ -683,21 +683,23 @@ guarantorName.error.length = Business name must be 182 characters or less
 guarantorName.error.invalidCharacter = Business name must not contain < and > and : and ;
 guarantorName.change.hidden = business name
 
-guarantorErn.checkYourAnswersLabel = Excise registration number (ERN)
+guarantorErn.checkYourAnswers.label = Excise registration number (ERN)
 guarantorErn.checkYourAnswers.notProvided = {0} section not complete
 
-guarantorVat.3.title = What is the goods owner’s VAT registration number?
-guarantorVat.3.heading = What is the goods owner’s VAT registration number?
-guarantorVat.2.title = What is the transporter’s VAT registration number?
-guarantorVat.2.heading = What is the transporter’s VAT registration number?
-guarantorVat.hint = This is 9 or 12 numbers, sometimes with ‘GB’ at the start, like 123456789 or GB123456789.
-guarantorVat.3.notUkVatLink = The goods owner is not VAT registered
-guarantorVat.2.notUkVatLink = The transporter is not VAT registered
-guarantorVat.checkYourAnswersLabel = VAT registration number
-guarantorVat.error.required = Enter a VAT registration number
-guarantorVat.error.length = VAT registration number must be 14 characters or less
-guarantorVat.error.alphanumeric = VAT registration number must only contain letters and numbers
-guarantorVat.change.hidden = VAT registration number
+guarantorVat.3.title = Is the goods owner VAT registered in the UK?
+guarantorVat.3.heading = Is the goods owner VAT registered in the UK?
+guarantorVat.2.title = Is the transporter VAT registered in the UK?
+guarantorVat.2.heading = Is the transporter VAT registered in the UK?
+guarantorVat.hint = A UK VAT registration number is 9 or 12 numbers, sometimes with ‘GB’ at the start, like 123456789 or GB123456789.
+guarantorVat.input.label = UK VAT registration number
+guarantorVat.3.error.radio.required = Select yes if the goods owner is VAT registered in the UK
+guarantorVat.2.error.radio.required = Select yes if the transporter is VAT registered in the UK
+guarantorVat.error.input.required = Enter a VAT registration number
+guarantorVat.error.input.length = VAT registration number must be 14 characters or less
+guarantorVat.error.input.alphanumeric = VAT registration number must only contain letters and numbers
+guarantorVat.checkYourAnswers.choice.label = VAT registered in the UK
+guarantorVat.checkYourAnswers.label = VAT registration number
+guarantorVat.checkYourAnswers.change.hidden = VAT registration number
 
 guarantorCheckAnswers.title = Check your answers
 guarantorCheckAnswers.heading = Check your answers

--- a/test-utils/fixtures/ItemFixtures.scala
+++ b/test-utils/fixtures/ItemFixtures.scala
@@ -31,7 +31,7 @@ import models.sections.journeyType.HowMovementTransported
 import models.sections.transportArranger._
 import models.sections.transportUnit.{TransportSealTypeModel, TransportUnitType}
 import models.submitCreateMovement._
-import models.{ExciseProductCode, ExemptOrganisationDetailsModel, GoodsType, UserAnswers}
+import models.{ExciseProductCode, ExemptOrganisationDetailsModel, GoodsType, UserAnswers, VatNumberModel}
 import pages.sections.consignee._
 import pages.sections.consignor._
 import pages.sections.destination._
@@ -399,7 +399,7 @@ trait ItemFixtures {
     .set(TransportArrangerPage, TransportArranger.GoodsOwner)
     .set(TransportArrangerNamePage, "arranger name")
     .set(TransportArrangerAddressPage, testUserAddress.copy(street = "arranger street"))
-    .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some("arranger vat")))
+    .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some("arranger vat")))
     // firstTransporterTrader
     .set(FirstTransporterNamePage, "first name")
     .set(FirstTransporterAddressPage, testUserAddress.copy(street = "first street"))
@@ -418,11 +418,8 @@ trait ItemFixtures {
     .set(GuarantorRequiredPage, true)
     .set(GuarantorNamePage, "guarantor name")
     .set(GuarantorAddressPage, testUserAddress.copy(street = "guarantor street"))
-    .set(GuarantorVatPage, "guarantor vat")
+    .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some("guarantor vat")))
     .set(GuarantorArrangerPage, GuarantorArranger.GoodsOwner)
-    .set(GuarantorNamePage, "guarantor name")
-    .set(GuarantorAddressPage, testUserAddress.copy(street = "guarantor street"))
-    .set(GuarantorVatPage, "guarantor vat")
     // bodyEadEsad
     .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
     .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)

--- a/test-utils/fixtures/messages/sections/guarantor/GuarantorErnVatEoriMessages.scala
+++ b/test-utils/fixtures/messages/sections/guarantor/GuarantorErnVatEoriMessages.scala
@@ -25,9 +25,8 @@ object GuarantorErnVatEoriMessages {
     _: i18n =>
 
     val cyaErnLabel = "Excise registration number (ERN)"
-    val cyaVatLabel = "VAT registration number"
-    val cyaEoriLabel = "EORI number"
-    val cyaNoVatOrEoriLabel = "VAT or EORI number"
+    val cyaVatChoiceLabel = "VAT registered in the UK"
+    val cyaVatInputLabel = "VAT registration number"
 
     val consigneeErnNotProvided = "Consignee section not complete"
   }

--- a/test-utils/fixtures/messages/sections/guarantor/GuarantorVatMessages.scala
+++ b/test-utils/fixtures/messages/sections/guarantor/GuarantorVatMessages.scala
@@ -31,15 +31,12 @@ object GuarantorVatMessages {
     }
 
     def heading()(implicit guarantorArranger: GuarantorArranger): String = guarantorArranger match {
-      case GoodsOwner => "What is the goods owner’s VAT registration number?"
-      case _ => "What is the transporter’s VAT registration number?"
+      case GoodsOwner => "Is the goods owner VAT registered in the UK?"
+      case _ => "Is the transporter VAT registered in the UK?"
     }
 
-    def notVatRegisteredLink()(implicit guarantorArranger: GuarantorArranger): String = guarantorArranger match {
-      case GoodsOwner => "The goods owner is not VAT registered"
-      case _ => "The transporter is not VAT registered"
-
-    }
+    val hint = "A UK VAT registration number is 9 or 12 numbers, sometimes with ‘GB’ at the start, like 123456789 or GB123456789."
+    val label = "UK VAT registration number"
 
     val cyaLabel = "VAT registration number"
     val cyaChangeHidden = "VAT registration number"

--- a/test/controllers/sections/guarantor/GuarantorArrangerControllerSpec.scala
+++ b/test/controllers/sections/guarantor/GuarantorArrangerControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.sections.guarantor.GuarantorArrangerFormProvider
 import mocks.services.MockUserAnswersService
 import models.sections.guarantor.GuarantorArranger
 import models.sections.guarantor.GuarantorArranger.{Consignee, Consignor, GoodsOwner, Transporter}
-import models.{CheckMode, NormalMode, UserAddress, UserAnswers}
+import models.{CheckMode, NormalMode, UserAddress, UserAnswers, VatNumberModel}
 import navigation.FakeNavigators.FakeGuarantorNavigator
 import pages.sections.guarantor._
 import play.api.data.Form
@@ -130,7 +130,7 @@ class GuarantorArrangerControllerSpec extends SpecBase with MockUserAnswersServi
             .set(GuarantorRequiredPage, true)
             .set(GuarantorArrangerPage, Transporter)
             .set(GuarantorNamePage, "Some name")
-            .set(GuarantorVatPage, "GB12345678")
+            .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some("GB12345678")))
             .set(GuarantorAddressPage, UserAddress(Some("1"), "Street", "town", "AA11AA")))) {
 
           val expectedAnswers = emptyUserAnswers

--- a/test/controllers/sections/guarantor/GuarantorVatControllerSpec.scala
+++ b/test/controllers/sections/guarantor/GuarantorVatControllerSpec.scala
@@ -148,7 +148,7 @@ class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
       .set(GuarantorRequiredPage, true)
       .set(GuarantorArrangerPage, Transporter))) {
 
-      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody((hasVatNumberField, ""))
+      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody(hasVatNumberField -> "")
       val boundForm = form.bind(Map(hasVatNumberField -> ""))
 
       val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)

--- a/test/controllers/sections/guarantor/GuarantorVatControllerSpec.scala
+++ b/test/controllers/sections/guarantor/GuarantorVatControllerSpec.scala
@@ -19,9 +19,11 @@ package controllers.sections.guarantor
 import base.SpecBase
 import controllers.actions.FakeDataRetrievalAction
 import forms.sections.guarantor.GuarantorVatFormProvider
+import forms.sections.guarantor.GuarantorVatFormProvider.hasVatNumberField
+import forms.sections.transportArranger.TransportArrangerVatFormProvider.vatNumberField
 import mocks.services.MockUserAnswersService
 import models.sections.guarantor.GuarantorArranger.Transporter
-import models.{NormalMode, UserAnswers}
+import models.{NormalMode, UserAnswers, VatNumberModel}
 import navigation.FakeNavigators.FakeGuarantorNavigator
 import pages.sections.guarantor.{GuarantorArrangerPage, GuarantorRequiredPage, GuarantorVatPage}
 import play.api.data.Form
@@ -34,7 +36,7 @@ import scala.concurrent.Future
 class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
 
   lazy val formProvider: GuarantorVatFormProvider = new GuarantorVatFormProvider()
-  lazy val form: Form[String] = formProvider()
+  lazy val form: Form[VatNumberModel] = formProvider(Transporter)
   lazy val view: GuarantorVatView = app.injector.instanceOf[GuarantorVatView]
 
   lazy val guarantorVatRoute: String = controllers.sections.guarantor.routes.GuarantorVatController.onPageLoad(testErn, testDraftId, NormalMode).url
@@ -72,15 +74,16 @@ class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
       Some(emptyUserAnswers
         .set(GuarantorRequiredPage, true)
         .set(GuarantorArrangerPage, Transporter)
-        .set(GuarantorVatPage, "answer"))) {
+        .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some(testVatNumber))))) {
 
       val result = testController.onPageLoad(testErn, testDraftId, NormalMode)(request)
 
       status(result) mustEqual OK
-      contentAsString(result) mustEqual view(form.fill("answer"), Transporter, NormalMode)(dataRequest(request), messages(request)).toString
+      contentAsString(result) mustEqual
+        view(form.fill(VatNumberModel(hasVatNumber = true, Some(testVatNumber))), Transporter, NormalMode)(dataRequest(request), messages(request)).toString
     }
 
-    "must redirect to the next page when valid data is submitted" in new Fixture(
+    "must redirect to the next page when valid data is submitted (Yes, with value)" in new Fixture(
       Some(emptyUserAnswers
         .set(GuarantorRequiredPage, true)
         .set(GuarantorArrangerPage, Transporter))) {
@@ -89,7 +92,10 @@ class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
         .set(GuarantorRequiredPage, true)
         .set(GuarantorArrangerPage, Transporter)))
 
-      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody(("value", "answer"))
+      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody(
+        hasVatNumberField -> "true",
+        vatNumberField -> testVatNumber
+      )
 
       val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)
 
@@ -97,7 +103,7 @@ class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
       redirectLocation(result).value mustEqual testOnwardRoute.url
     }
 
-    "must redirect to the next page when the NONGBVAT link is clicked" in new Fixture(
+    "must redirect to the next page when valid data is submitted (No)" in new Fixture(
       Some(emptyUserAnswers
         .set(GuarantorRequiredPage, true)
         .set(GuarantorArrangerPage, Transporter))) {
@@ -106,9 +112,9 @@ class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
         .set(GuarantorRequiredPage, true)
         .set(GuarantorArrangerPage, Transporter)))
 
-      val req = FakeRequest(GET, controllers.sections.guarantor.routes.GuarantorVatController.onNonGbVAT(testErn, testDraftId, NormalMode).url)
+      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody(hasVatNumberField -> "false")
 
-      val result = testController.onNonGbVAT(testErn, testDraftId, NormalMode)(req)
+      val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual testOnwardRoute.url
@@ -142,8 +148,8 @@ class GuarantorVatControllerSpec extends SpecBase with MockUserAnswersService {
       .set(GuarantorRequiredPage, true)
       .set(GuarantorArrangerPage, Transporter))) {
 
-      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody(("value", ""))
-      val boundForm = form.bind(Map("value" -> ""))
+      val req = FakeRequest(POST, guarantorVatRoute).withFormUrlEncodedBody((hasVatNumberField, ""))
+      val boundForm = form.bind(Map(hasVatNumberField -> ""))
 
       val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)
 

--- a/test/controllers/sections/transportArranger/TransportArrangerVatControllerSpec.scala
+++ b/test/controllers/sections/transportArranger/TransportArrangerVatControllerSpec.scala
@@ -19,11 +19,10 @@ package controllers.sections.transportArranger
 import base.SpecBase
 import controllers.actions.FakeDataRetrievalAction
 import forms.sections.transportArranger.TransportArrangerVatFormProvider
-import forms.sections.transportArranger.TransportArrangerVatFormProvider.{hasVatNumberField, transportArrangerVatNumberField, transportArrangerVatNumberRequired}
+import forms.sections.transportArranger.TransportArrangerVatFormProvider.{hasVatNumberField, vatNumberField, vatNumberRequired}
 import mocks.services.MockUserAnswersService
 import models.sections.transportArranger.TransportArranger.GoodsOwner
-import models.sections.transportArranger.TransportArrangerVatModel
-import models.{NormalMode, UserAnswers}
+import models.{NormalMode, UserAnswers, VatNumberModel}
 import navigation.FakeNavigators.FakeTransportArrangerNavigator
 import pages.sections.transportArranger.{TransportArrangerPage, TransportArrangerVatPage}
 import play.api.data.Form
@@ -39,10 +38,10 @@ class TransportArrangerVatControllerSpec extends SpecBase with MockUserAnswersSe
 
   val goodsOwnerUserAnswers: UserAnswers = emptyUserAnswers.set(TransportArrangerPage, GoodsOwner)
 
-  val inputModelWithVATNumber: TransportArrangerVatModel = TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some("GB123456789"))
+  val inputModelWithVATNumber: VatNumberModel = VatNumberModel(hasVatNumber = true, Some("GB123456789"))
 
   lazy val formProvider: TransportArrangerVatFormProvider = new TransportArrangerVatFormProvider()
-  lazy val form: Form[TransportArrangerVatModel] = formProvider(GoodsOwner)
+  lazy val form: Form[VatNumberModel] = formProvider(GoodsOwner)
   lazy val view: TransportArrangerVatView = app.injector.instanceOf[TransportArrangerVatView]
 
   lazy val transportArrangerVatSubmitAction: Call = routes.TransportArrangerVatController.onSubmit(testErn, testDraftId, NormalMode)
@@ -96,7 +95,7 @@ class TransportArrangerVatControllerSpec extends SpecBase with MockUserAnswersSe
     "must redirect to the next page when valid data is submitted (yes selected with VAT number)" in new Fixture() {
       MockUserAnswersService.set().returns(Future.successful(goodsOwnerUserAnswers))
 
-      val result = controller.onSubmit(testErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(hasVatNumberField -> "true", transportArrangerVatNumberField -> testVatNumber))
+      val result = controller.onSubmit(testErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(hasVatNumberField -> "true", vatNumberField -> testVatNumber))
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual testOnwardRoute.url
@@ -106,9 +105,9 @@ class TransportArrangerVatControllerSpec extends SpecBase with MockUserAnswersSe
 
       implicit val msgs: Messages = messages(request)
 
-      val boundForm = form.fill(inputModelWithVATNumber.copy(transportArrangerVatNumber = None)).withError(transportArrangerVatNumberField, msgs(transportArrangerVatNumberRequired))
+      val boundForm = form.fill(inputModelWithVATNumber.copy(vatNumber = None)).withError(vatNumberField, msgs(vatNumberRequired))
 
-      val result = controller.onSubmit(testErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(hasVatNumberField -> "true", transportArrangerVatNumberField -> ""))
+      val result = controller.onSubmit(testErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(hasVatNumberField -> "true", vatNumberField -> ""))
 
       status(result) mustEqual BAD_REQUEST
       contentAsString(result) mustEqual

--- a/test/forms/sections/guarantor/GuarantorVatFormProviderSpec.scala
+++ b/test/forms/sections/guarantor/GuarantorVatFormProviderSpec.scala
@@ -16,50 +16,119 @@
 
 package forms.sections.guarantor
 
+import fixtures.BaseFixtures
 import forms.ONLY_ALPHANUMERIC_REGEX
 import forms.behaviours.StringFieldBehaviours
+import models.VatNumberModel
+import models.sections.guarantor.GuarantorArranger
+import models.sections.guarantor.GuarantorArranger.{GoodsOwner, Transporter}
 import play.api.data.FormError
 
-class GuarantorVatFormProviderSpec extends StringFieldBehaviours {
+class GuarantorVatFormProviderSpec extends StringFieldBehaviours with BaseFixtures {
 
-  val requiredKey = "guarantorVat.error.required"
-  val lengthKey = "guarantorVat.error.length"
-  val alphanumericKey = "guarantorVat.error.alphanumeric"
+  val lengthKey = "guarantorVat.error.input.length"
+  val inputRequiredKey = "guarantorVat.error.input.required"
+  val alphanumericKey = "guarantorVat.error.input.alphanumeric"
   val maxLength = 14
 
-  val form = new GuarantorVatFormProvider()()
+  class Test(guarantorArranger: GuarantorArranger = GoodsOwner) {
+    val radioRequiredKey: String = s"guarantorVat.$guarantorArranger.error.radio.required"
+    val form = new GuarantorVatFormProvider()(guarantorArranger)
+  }
 
-  ".value" - {
+  "when binding 'Yes'" - {
 
-    val fieldName = "value"
+    "when VAT number is not provided" - {
 
-    behave like fieldThatBindsValidData(
-      form,
-      fieldName,
-      "0" * maxLength
-    )
+      "must error when binding the form" in new Test() {
 
-    behave like fieldWithMaxLength(
-      form,
-      fieldName,
-      maxLength = maxLength,
-      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
-    )
+        val boundForm = form.bind(Map(GuarantorVatFormProvider.hasVatNumberField -> "true"))
 
-    behave like mandatoryField(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
-    )
-
-    "only allow alphanumerics" in {
-      val boundForm = form.bind(Map("value" -> "ABCD@/"))
-      boundForm.errors mustBe Seq(FormError(fieldName, alphanumericKey, Seq(ONLY_ALPHANUMERIC_REGEX)))
+        boundForm.errors mustBe Seq(FormError(GuarantorVatFormProvider.vatNumberField, inputRequiredKey, Seq()))
+      }
     }
 
-    "must allow - and spaces but trim them out" in {
-      val boundForm = form.bind(Map("value" -> "GB12 456-178"))
-      boundForm.value mustBe Some("GB12456178")
+    "when VAT number contains invalid characters" - {
+
+      "must error when binding the form" in new Test() {
+
+        val boundForm = form.bind(Map(
+          GuarantorVatFormProvider.hasVatNumberField -> "true",
+          GuarantorVatFormProvider.vatNumberField -> "<"
+        ))
+
+        boundForm.errors mustBe Seq(FormError(GuarantorVatFormProvider.vatNumberField, alphanumericKey, Seq(ONLY_ALPHANUMERIC_REGEX)))
+      }
+    }
+
+    "when VAT number is too long" - {
+
+      "must error when binding the form" in new Test() {
+
+        val boundForm = form.bind(Map(
+          GuarantorVatFormProvider.hasVatNumberField -> "true",
+          GuarantorVatFormProvider.vatNumberField -> "a" * (maxLength + 1)
+        ))
+
+        boundForm.errors mustBe Seq(FormError(GuarantorVatFormProvider.vatNumberField, lengthKey, Seq(maxLength)))
+      }
+    }
+
+    "when VAT number is valid" - {
+
+      "must bind the form successfully when true with value (spaces exist but trim them out)" in new Test() {
+
+        val boundForm = form.bind(Map(
+          GuarantorVatFormProvider.hasVatNumberField -> "true",
+          GuarantorVatFormProvider.vatNumberField -> "GB123 456-178"
+        ))
+
+        boundForm.value mustBe Some(VatNumberModel(hasVatNumber = true, Some("GB123456178")))
+      }
+
+      "must bind the form successfully when true with value" in new Test() {
+
+        val boundForm = form.bind(Map(
+          GuarantorVatFormProvider.hasVatNumberField -> "true",
+          GuarantorVatFormProvider.vatNumberField -> testVatNumber
+        ))
+
+        boundForm.value mustBe Some(VatNumberModel(hasVatNumber = true, Some(testVatNumber)))
+      }
+    }
+  }
+
+  "when binding 'No'" - {
+
+    "must bind the form successfully when false with value (should be transformed to None on bind)" in new Test() {
+
+      val boundForm = form.bind(Map(
+        GuarantorVatFormProvider.hasVatNumberField -> "false",
+        GuarantorVatFormProvider.vatNumberField -> "brand"
+      ))
+
+      boundForm.value mustBe Some(VatNumberModel(hasVatNumber = false, None))
+    }
+
+    "must bind the form successfully when false with NO value" in new Test() {
+
+      val boundForm = form.bind(Map(GuarantorVatFormProvider.hasVatNumberField -> "false"))
+
+      boundForm.value mustBe Some(VatNumberModel(hasVatNumber = false, None))
+    }
+  }
+
+
+  Seq(Transporter, GoodsOwner).foreach { arrangerType =>
+
+    s"when an option hasn't been selected for arranger type: $arrangerType" - {
+
+      "must error with correct error message when binding the form" in new Test(arrangerType) {
+
+        val boundForm = form.bind(Map(GuarantorVatFormProvider.hasVatNumberField -> ""))
+
+        boundForm.errors mustBe Seq(FormError(GuarantorVatFormProvider.hasVatNumberField, radioRequiredKey, Seq()))
+      }
     }
   }
 }

--- a/test/forms/sections/transportArranger/TransportArrangerVatFormProviderSpec.scala
+++ b/test/forms/sections/transportArranger/TransportArrangerVatFormProviderSpec.scala
@@ -19,8 +19,9 @@ package forms.sections.transportArranger
 import fixtures.BaseFixtures
 import forms.ONLY_ALPHANUMERIC_REGEX
 import forms.behaviours.StringFieldBehaviours
+import models.VatNumberModel
 import models.sections.transportArranger.TransportArranger.{GoodsOwner, Other}
-import models.sections.transportArranger.{TransportArranger, TransportArrangerVatModel}
+import models.sections.transportArranger.TransportArranger
 import play.api.data.FormError
 
 class TransportArrangerVatFormProviderSpec extends StringFieldBehaviours with BaseFixtures {
@@ -40,11 +41,11 @@ class TransportArrangerVatFormProviderSpec extends StringFieldBehaviours with Ba
 
         val boundForm = form.bind(Map(
           TransportArrangerVatFormProvider.hasVatNumberField -> "true",
-          TransportArrangerVatFormProvider.transportArrangerVatNumberField -> "<"
+          TransportArrangerVatFormProvider.vatNumberField -> "<"
         ))
 
         boundForm.errors mustBe Seq(FormError(
-          TransportArrangerVatFormProvider.transportArrangerVatNumberField,
+          TransportArrangerVatFormProvider.vatNumberField,
           alphanumericKey,
           Seq(ONLY_ALPHANUMERIC_REGEX)
         ))
@@ -57,11 +58,11 @@ class TransportArrangerVatFormProviderSpec extends StringFieldBehaviours with Ba
 
         val boundForm = form.bind(Map(
           TransportArrangerVatFormProvider.hasVatNumberField -> "true",
-          TransportArrangerVatFormProvider.transportArrangerVatNumberField -> "a" * (maxLength + 1)
+          TransportArrangerVatFormProvider.vatNumberField -> "a" * (maxLength + 1)
         ))
 
         boundForm.errors mustBe Seq(FormError(
-          TransportArrangerVatFormProvider.transportArrangerVatNumberField,
+          TransportArrangerVatFormProvider.vatNumberField,
           lengthKey,
           Seq(maxLength)
         ))
@@ -74,20 +75,20 @@ class TransportArrangerVatFormProviderSpec extends StringFieldBehaviours with Ba
 
         val boundForm = form.bind(Map(
           TransportArrangerVatFormProvider.hasVatNumberField -> "true",
-          TransportArrangerVatFormProvider.transportArrangerVatNumberField -> "GB123 456-178"
+          TransportArrangerVatFormProvider.vatNumberField -> "GB123 456-178"
         ))
 
-        boundForm.value mustBe Some(TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some("GB123456178")))
+        boundForm.value mustBe Some(VatNumberModel(hasVatNumber = true, Some("GB123456178")))
       }
 
       "must bind the form successfully when true with value" in {
 
         val boundForm = form.bind(Map(
           TransportArrangerVatFormProvider.hasVatNumberField -> "true",
-          TransportArrangerVatFormProvider.transportArrangerVatNumberField -> testVatNumber
+          TransportArrangerVatFormProvider.vatNumberField -> testVatNumber
         ))
 
-        boundForm.value mustBe Some(TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some(testVatNumber)))
+        boundForm.value mustBe Some(VatNumberModel(hasVatNumber = true, Some(testVatNumber)))
       }
     }
   }
@@ -98,10 +99,10 @@ class TransportArrangerVatFormProviderSpec extends StringFieldBehaviours with Ba
 
       val boundForm = form.bind(Map(
         TransportArrangerVatFormProvider.hasVatNumberField -> "false",
-        TransportArrangerVatFormProvider.transportArrangerVatNumberField -> "brand"
+        TransportArrangerVatFormProvider.vatNumberField -> "brand"
       ))
 
-      boundForm.value mustBe Some(TransportArrangerVatModel(hasTransportArrangerVatNumber = false, None))
+      boundForm.value mustBe Some(VatNumberModel(hasVatNumber = false, None))
     }
 
     "must bind the form successfully when false with NO value" in {
@@ -110,7 +111,7 @@ class TransportArrangerVatFormProviderSpec extends StringFieldBehaviours with Ba
         TransportArrangerVatFormProvider.hasVatNumberField -> "false"
       ))
 
-      boundForm.value mustBe Some(TransportArrangerVatModel(hasTransportArrangerVatNumber = false, None))
+      boundForm.value mustBe Some(VatNumberModel(hasVatNumber = false, None))
     }
   }
 

--- a/test/models/submitCreateMovement/MovementGuaranteeModelSpec.scala
+++ b/test/models/submitCreateMovement/MovementGuaranteeModelSpec.scala
@@ -17,6 +17,7 @@
 package models.submitCreateMovement
 
 import base.SpecBase
+import models.VatNumberModel
 import models.requests.DataRequest
 import models.sections.guarantor.GuarantorArranger
 import pages.sections.guarantor._
@@ -36,7 +37,7 @@ class MovementGuaranteeModelSpec extends SpecBase {
             .set(GuarantorArrangerPage, GuarantorArranger.GoodsOwner)
             .set(GuarantorNamePage, "name")
             .set(GuarantorAddressPage, testUserAddress)
-            .set(GuarantorVatPage, "vat")
+            .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some("vat")))
             .set(DestinationTypePage, MovementScenario.EuTaxWarehouse),
           testNorthernIrelandErn
         )
@@ -52,7 +53,7 @@ class MovementGuaranteeModelSpec extends SpecBase {
             .set(GuarantorArrangerPage, GuarantorArranger.GoodsOwner)
             .set(GuarantorNamePage, "name")
             .set(GuarantorAddressPage, testUserAddress)
-            .set(GuarantorVatPage, "vat")
+            .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some("vat")))
             .set(DestinationTypePage, MovementScenario.GbTaxWarehouse),
           testNorthernIrelandErn
         )
@@ -68,7 +69,7 @@ class MovementGuaranteeModelSpec extends SpecBase {
             .set(GuarantorArrangerPage, GuarantorArranger.GoodsOwner)
             .set(GuarantorNamePage, "name")
             .set(GuarantorAddressPage, testUserAddress)
-            .set(GuarantorVatPage, "vat")
+            .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some("vat")))
         )
 
         MovementGuaranteeModel.apply mustBe MovementGuaranteeModel(GuarantorArranger.GoodsOwner, Some(Seq(TraderModel(
@@ -90,7 +91,7 @@ class MovementGuaranteeModelSpec extends SpecBase {
             .set(GuarantorArrangerPage, GuarantorArranger.GoodsOwner)
             .set(GuarantorNamePage, "name")
             .set(GuarantorAddressPage, testUserAddress)
-            .set(GuarantorVatPage, "vat"),
+            .set(GuarantorVatPage, VatNumberModel(hasVatNumber = true, Some("vat"))),
           testNorthernIrelandErn
         )
 

--- a/test/models/submitCreateMovement/TraderModelSpec.scala
+++ b/test/models/submitCreateMovement/TraderModelSpec.scala
@@ -17,11 +17,12 @@
 package models.submitCreateMovement
 
 import base.SpecBase
+import models.VatNumberModel
 import models.requests.DataRequest
 import models.sections.guarantor.GuarantorArranger
 import models.sections.info.movementScenario.MovementScenario
 import models.sections.info.movementScenario.MovementScenario._
-import models.sections.transportArranger.{TransportArranger, TransportArrangerVatModel}
+import models.sections.transportArranger.TransportArranger
 import pages.sections.consignee._
 import pages.sections.consignor._
 import pages.sections.destination._
@@ -449,7 +450,7 @@ class TraderModelSpec extends SpecBase {
                 .set(TransportArrangerPage, transportArranger)
                 .set(TransportArrangerNamePage, "arranger name")
                 .set(TransportArrangerAddressPage, testUserAddress.copy(street = "arranger street"))
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some("arranger vat")))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some("arranger vat")))
             )
 
             TraderModel.applyTransportArranger mustBe Some(transportArrangerTrader)
@@ -501,7 +502,7 @@ class TraderModelSpec extends SpecBase {
               emptyUserAnswers
                 .set(GuarantorNamePage, "guarantor name")
                 .set(GuarantorAddressPage, testUserAddress.copy(street = "guarantor street"))
-                .set(GuarantorVatPage, "guarantor vat")
+                .set(GuarantorVatPage, VatNumberModel(true, Some("guarantor vat")))
             )
 
             TraderModel.applyGuarantor(guarantorArranger) mustBe Some(guarantorTrader)

--- a/test/navigation/TransportArrangerNavigatorSpec.scala
+++ b/test/navigation/TransportArrangerNavigatorSpec.scala
@@ -19,8 +19,7 @@ package navigation
 import base.SpecBase
 import controllers.routes
 import models.sections.transportArranger.TransportArranger.{Consignee, Consignor, GoodsOwner, Other}
-import models.sections.transportArranger.TransportArrangerVatModel
-import models.{CheckMode, NormalMode, ReviewMode}
+import models.{CheckMode, NormalMode, ReviewMode, VatNumberModel}
 import pages.Page
 import pages.sections.transportArranger._
 
@@ -127,7 +126,7 @@ class TransportArrangerNavigatorSpec extends SpecBase {
 
               val userAnswers = emptyUserAnswers
                 .set(TransportArrangerPage, GoodsOwner)
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some(testVatNumber)))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some(testVatNumber)))
 
               navigator.nextPage(TransportArrangerPage, CheckMode, userAnswers) mustBe
                 controllers.sections.transportArranger.routes.TransportArrangerNameController.onPageLoad(testErn, testDraftId, NormalMode)
@@ -141,7 +140,7 @@ class TransportArrangerNavigatorSpec extends SpecBase {
               val userAnswers = emptyUserAnswers
                 .set(TransportArrangerPage, Other)
                 .set(TransportArrangerNamePage, "Jeff")
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some(testVatNumber)))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some(testVatNumber)))
                 .set(TransportArrangerAddressPage, testUserAddress)
 
               navigator.nextPage(TransportArrangerPage, CheckMode, userAnswers) mustBe

--- a/test/pages/sections/guarantor/GuarantorSectionSpec.scala
+++ b/test/pages/sections/guarantor/GuarantorSectionSpec.scala
@@ -17,7 +17,7 @@
 package pages.sections.guarantor
 
 import base.SpecBase
-import models.UserAddress
+import models.{UserAddress, VatNumberModel}
 import models.requests.DataRequest
 import models.sections.guarantor.GuarantorArranger.{Consignee, Consignor, GoodsOwner, Transporter}
 import play.api.test.FakeRequest
@@ -56,7 +56,7 @@ class GuarantorSectionSpec extends SpecBase {
                 .set(GuarantorRequiredPage, true)
                 .set(GuarantorArrangerPage, arranger)
                 .set(GuarantorNamePage, "")
-                .set(GuarantorVatPage, "")
+                .set(GuarantorVatPage, VatNumberModel(hasVatNumber = false, None))
                 .set(GuarantorAddressPage, UserAddress(None, "", "", ""))
             )
             GuarantorSection.isCompleted mustBe true
@@ -86,7 +86,7 @@ class GuarantorSectionSpec extends SpecBase {
                 .set(GuarantorRequiredPage, true)
                 .set(GuarantorArrangerPage, arranger)
                 .set(GuarantorNamePage, "")
-                .set(GuarantorVatPage, "")
+                .set(GuarantorVatPage, VatNumberModel(hasVatNumber = false, None))
             )
             GuarantorSection.isCompleted mustBe false
           }

--- a/test/pages/sections/transportArranger/TransportArrangerSectionSpec.scala
+++ b/test/pages/sections/transportArranger/TransportArrangerSectionSpec.scala
@@ -17,10 +17,9 @@
 package pages.sections.transportArranger
 
 import base.SpecBase
-import models.UserAddress
+import models.{UserAddress, VatNumberModel}
 import models.requests.DataRequest
 import models.sections.transportArranger.TransportArranger._
-import models.sections.transportArranger.TransportArrangerVatModel
 import play.api.test.FakeRequest
 
 class TransportArrangerSectionSpec extends SpecBase {
@@ -47,7 +46,7 @@ class TransportArrangerSectionSpec extends SpecBase {
               emptyUserAnswers
                 .set(TransportArrangerPage, arranger)
                 .set(TransportArrangerNamePage, "")
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some("arranger vat")))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some("arranger vat")))
                 .set(TransportArrangerAddressPage, UserAddress(None, "", "", ""))
             )
             TransportArrangerSection.isCompleted mustBe true

--- a/test/viewmodels/checkAnswers/sections/guarantor/GuarantorCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/guarantor/GuarantorCheckAnswersHelperSpec.scala
@@ -18,6 +18,7 @@ package viewmodels.checkAnswers.sections.guarantor
 
 import base.SpecBase
 import fixtures.messages.sections.guarantor.GuarantorArrangerMessages.English
+import models.VatNumberModel
 import models.requests.DataRequest
 import models.sections.guarantor.GuarantorArranger
 import models.sections.guarantor.GuarantorArranger.{GoodsOwner, Transporter}
@@ -44,7 +45,7 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
       GuarantorArranger.displayValues.foreach {
         case value@(GoodsOwner | Transporter) =>
 
-          "must render five rows (GuarantorRequired is included)" - {
+          "must render six rows (GuarantorRequired is included)" - {
             s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
               implicit val request: DataRequest[_] = dataRequest(
                 FakeRequest(),
@@ -54,11 +55,11 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
                   .set(GuarantorRequiredPage, true)
                   .set(GuarantorArrangerPage, value)
                   .set(GuarantorNamePage, "guarantor name")
-                  .set(GuarantorVatPage, "gurantor123")
+                  .set(GuarantorVatPage, VatNumberModel(true, Some("gurantor123")))
                   .set(GuarantorAddressPage, testUserAddress),
                 testNorthernIrelandErn
               )
-              helper.summaryList()(request, msgs).rows.length mustBe 5
+              helper.summaryList()(request, msgs).rows.length mustBe 6
             }
           }
         case value =>
@@ -85,7 +86,7 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
       GuarantorArranger.displayValues.foreach {
         case value@(GoodsOwner | Transporter) =>
 
-          "must render four rows (GuarantorRequired is excluded as it must be true and can't be changed)" - {
+          "must render five rows (GuarantorRequired is excluded as it must be true and can't be changed)" - {
             s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
               implicit val request: DataRequest[_] = dataRequest(
                 FakeRequest(),
@@ -95,11 +96,11 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
                   .set(GuarantorRequiredPage, true)
                   .set(GuarantorArrangerPage, value)
                   .set(GuarantorNamePage, "guarantor name")
-                  .set(GuarantorVatPage, "gurantor123")
+                  .set(GuarantorVatPage, VatNumberModel(true, Some("gurantor123")))
                   .set(GuarantorAddressPage, testUserAddress),
                 testNorthernIrelandErn
               )
-              helper.summaryList()(request, msgs).rows.length mustBe 4
+              helper.summaryList()(request, msgs).rows.length mustBe 5
             }
           }
         case value =>
@@ -127,7 +128,7 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
       GuarantorArranger.displayValues.foreach {
         case value@(GoodsOwner | Transporter) =>
 
-          "must render five rows" - {
+          "must render six rows" - {
             s"when GuarantorArranger value is ${value.getClass.getSimpleName.stripSuffix("$")}" in new Test {
               implicit val request: DataRequest[_] = dataRequest(
                 FakeRequest(),
@@ -136,10 +137,10 @@ class GuarantorCheckAnswersHelperSpec extends SpecBase with MockFactory {
                   .set(GuarantorRequiredPage, true)
                   .set(GuarantorArrangerPage, value)
                   .set(GuarantorNamePage, "guarantor name")
-                  .set(GuarantorVatPage, "gurantor123")
+                  .set(GuarantorVatPage, VatNumberModel(true, Some("gurantor123")))
                   .set(GuarantorAddressPage, testUserAddress)
               )
-              helper.summaryList()(request, msgs).rows.length mustBe 5
+              helper.summaryList()(request, msgs).rows.length mustBe 6
             }
           }
         case value =>

--- a/test/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerCheckAnswersHelperSpec.scala
@@ -18,8 +18,9 @@ package viewmodels.checkAnswers.sections.transportArranger
 
 import base.SpecBase
 import fixtures.messages.sections.transportArranger.TransportArrangerMessages
+import models.VatNumberModel
 import models.requests.DataRequest
-import models.sections.transportArranger.{TransportArranger, TransportArrangerVatModel}
+import models.sections.transportArranger.TransportArranger
 import models.sections.transportArranger.TransportArranger.{GoodsOwner, Other}
 import org.scalamock.scalatest.MockFactory
 import pages.sections.transportArranger.{TransportArrangerPage, TransportArrangerVatPage}
@@ -33,7 +34,7 @@ class TransportArrangerCheckAnswersHelperSpec extends SpecBase with MockFactory 
     val helper = new TransportArrangerCheckAnswersHelper()
   }
 
-  val vatNumberInputModel: TransportArrangerVatModel = TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some(testVatNumber))
+  val vatNumberInputModel: VatNumberModel = VatNumberModel(hasVatNumber = true, Some(testVatNumber))
 
   "summaryList" - {
     TransportArranger.values.foreach {

--- a/test/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatChoiceSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatChoiceSummarySpec.scala
@@ -18,9 +18,8 @@ package viewmodels.checkAnswers.sections.transportArranger
 
 import base.SpecBase
 import fixtures.messages.sections.transportArranger.TransportArrangerVatMessages
-import models.CheckMode
+import models.{CheckMode, VatNumberModel}
 import models.sections.transportArranger.TransportArranger.{Consignor, GoodsOwner, Other}
-import models.sections.transportArranger.TransportArrangerVatModel
 import org.scalatest.matchers.must.Matchers
 import pages.sections.transportArranger.{TransportArrangerPage, TransportArrangerVatPage}
 import play.api.i18n.{Messages, MessagesApi}
@@ -67,7 +66,7 @@ class TransportArrangerVatChoiceSummarySpec extends SpecBase with Matchers {
 
               implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
                 .set(TransportArrangerPage, Other)
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some(testVatNumber)))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some(testVatNumber)))
               )
 
               TransportArrangerVatChoiceSummary.row() mustBe
@@ -90,7 +89,7 @@ class TransportArrangerVatChoiceSummarySpec extends SpecBase with Matchers {
 
               implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
                 .set(TransportArrangerPage, Other)
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = false, None))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = false, None))
               )
 
               TransportArrangerVatChoiceSummary.row() mustBe

--- a/test/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportArranger/TransportArrangerVatSummarySpec.scala
@@ -18,9 +18,8 @@ package viewmodels.checkAnswers.sections.transportArranger
 
 import base.SpecBase
 import fixtures.messages.sections.transportArranger.TransportArrangerVatMessages
-import models.CheckMode
+import models.{CheckMode, VatNumberModel}
 import models.sections.transportArranger.TransportArranger.{Consignor, GoodsOwner, Other}
-import models.sections.transportArranger.TransportArrangerVatModel
 import org.scalatest.matchers.must.Matchers
 import pages.sections.transportArranger.{TransportArrangerPage, TransportArrangerVatPage}
 import play.api.i18n.{Messages, MessagesApi}
@@ -68,7 +67,7 @@ class TransportArrangerVatSummarySpec extends SpecBase with Matchers {
 
               implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
                 .set(TransportArrangerPage, GoodsOwner)
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = false, None))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = false, None))
               )
 
               TransportArrangerVatSummary.row() mustBe None
@@ -81,7 +80,7 @@ class TransportArrangerVatSummarySpec extends SpecBase with Matchers {
 
               implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
                 .set(TransportArrangerPage, Other)
-                .set(TransportArrangerVatPage, TransportArrangerVatModel(hasTransportArrangerVatNumber = true, Some(testVatNumber)))
+                .set(TransportArrangerVatPage, VatNumberModel(hasVatNumber = true, Some(testVatNumber)))
               )
 
               TransportArrangerVatSummary.row() mustBe

--- a/test/views/sections/guarantor/GuarantorVatViewSpec.scala
+++ b/test/views/sections/guarantor/GuarantorVatViewSpec.scala
@@ -46,7 +46,7 @@ class GuarantorVatViewSpec extends SpecBase with ViewBehaviours {
             implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), emptyUserAnswers)
 
            lazy val view = app.injector.instanceOf[GuarantorVatView]
-            val form = app.injector.instanceOf[GuarantorVatFormProvider].apply()
+            val form = app.injector.instanceOf[GuarantorVatFormProvider].apply(validGuarantorArranger)
 
             implicit val doc: Document = Jsoup.parse(
               view(
@@ -58,7 +58,11 @@ class GuarantorVatViewSpec extends SpecBase with ViewBehaviours {
             behave like pageWithExpectedElementsAndMessages(Seq(
               Selectors.title -> messagesForLanguage.title,
               Selectors.h1 -> messagesForLanguage.heading,
-              Selectors.link(1) -> messagesForLanguage.notVatRegisteredLink,
+              Selectors.hint -> messagesForLanguage.hint,
+              Selectors.radioButton(1) -> messagesForLanguage.yes,
+              Selectors.label("vatNumber") -> messagesForLanguage.label,
+              //Note, this is radio button 2 but index is 3 due to hidden HTML conditional content for radio 1
+              Selectors.radioButton(3) -> messagesForLanguage.no,
               Selectors.button -> messagesForLanguage.saveAndContinue,
               Selectors.saveAndExitLink -> messagesForLanguage.returnToDraft
             ))

--- a/test/views/sections/guarantor/GuarantorVatViewSpec.scala
+++ b/test/views/sections/guarantor/GuarantorVatViewSpec.scala
@@ -60,7 +60,7 @@ class GuarantorVatViewSpec extends SpecBase with ViewBehaviours {
               Selectors.h1 -> messagesForLanguage.heading,
               Selectors.hint -> messagesForLanguage.hint,
               Selectors.radioButton(1) -> messagesForLanguage.yes,
-              Selectors.label("vatNumber") -> messagesForLanguage.label,
+              Selectors.label(GuarantorVatFormProvider.vatNumberField) -> messagesForLanguage.label,
               //Note, this is radio button 2 but index is 3 due to hidden HTML conditional content for radio 1
               Selectors.radioButton(3) -> messagesForLanguage.no,
               Selectors.button -> messagesForLanguage.saveAndContinue,

--- a/test/views/sections/transportArranger/TransportArrangerVatViewSpec.scala
+++ b/test/views/sections/transportArranger/TransportArrangerVatViewSpec.scala
@@ -58,7 +58,7 @@ class TransportArrangerVatViewSpec extends SpecBase with ViewBehaviours {
             Selectors.h1 -> messagesForLanguage.goodsOwnerHeading,
             Selectors.hint -> messagesForLanguage.hint,
             Selectors.radioButton(1) -> messagesForLanguage.yes,
-            Selectors.label(TransportArrangerVatFormProvider.transportArrangerVatNumberField) -> messagesForLanguage.vatNumberLabel,
+            Selectors.label(TransportArrangerVatFormProvider.vatNumberField) -> messagesForLanguage.vatNumberLabel,
             //Note, this is radio button 2 but index is 3 due to hidden HTML conditional content for radio 1
             Selectors.radioButton(3) -> messagesForLanguage.no,
             Selectors.button -> messagesForLanguage.saveAndContinue,
@@ -73,7 +73,7 @@ class TransportArrangerVatViewSpec extends SpecBase with ViewBehaviours {
             Selectors.h1 -> messagesForLanguage.otherHeading,
             Selectors.hint -> messagesForLanguage.hint,
             Selectors.radioButton(1) -> messagesForLanguage.yes,
-            Selectors.label(TransportArrangerVatFormProvider.transportArrangerVatNumberField) -> messagesForLanguage.vatNumberLabel,
+            Selectors.label(TransportArrangerVatFormProvider.vatNumberField) -> messagesForLanguage.vatNumberLabel,
             //Note, this is radio button 2 but index is 3 due to hidden HTML conditional content for radio 1
             Selectors.radioButton(3) -> messagesForLanguage.no,
             Selectors.button -> messagesForLanguage.saveAndContinue,


### PR DESCRIPTION
Includes:
- Refactor to make a generic `VatNumberModel` that can be shared on other views
- Uses the `play-conditional-form-mapping` library to tidy up and fix a bug with the way the Yes/No reveal and form validation works. (Fix only applied to the GuarantorVat page - other pages will be fixed as part of ETFE-3681