### PR TITLE
[ETFE-3658] Update the Place of Dispatch logic

### DIFF
--- a/app/config/Constants.scala
+++ b/app/config/Constants.scala
@@ -20,4 +20,5 @@ object Constants {
   val NONGBVAT = "NONGBVAT"
   val BODYEADESAD = "BodyEadEsad"
   val XI_POSTCODE = "BT"
+  val NI_PREFIX = "XI"
 }

--- a/app/controllers/AddressControllerBase.scala
+++ b/app/controllers/AddressControllerBase.scala
@@ -38,7 +38,9 @@ trait AddressControllerBase extends BaseNavigationController with AuthActionHelp
 
   def onPageLoad(ern: String, draftId: String, mode: Mode): Action[AnyContent] =
     authorisedDataRequest(ern, draftId) { implicit request =>
-      renderView(Ok, fillForm(addressPage, formProvider(addressPage)), mode)
+      // Ensure the page doesn't load with errors by setting errors to an empty Seq() after filling.
+      // This is to cater for pre-popped addresses, which should only error once the user submits
+      renderView(Ok, fillForm(addressPage, formProvider(addressPage)).copy(errors = Seq()), mode)
     }
 
   def onSubmit(ern: String, draftId: String, mode: Mode): Action[AnyContent] =

--- a/app/controllers/AddressControllerBase.scala
+++ b/app/controllers/AddressControllerBase.scala
@@ -38,9 +38,7 @@ trait AddressControllerBase extends BaseNavigationController with AuthActionHelp
 
   def onPageLoad(ern: String, draftId: String, mode: Mode): Action[AnyContent] =
     authorisedDataRequest(ern, draftId) { implicit request =>
-      // Ensure the page doesn't load with errors by setting errors to an empty Seq() after filling.
-      // This is to cater for pre-popped addresses, which should only error once the user submits
-      renderView(Ok, fillForm(addressPage, formProvider(addressPage)).copy(errors = Seq()), mode)
+      renderView(Ok, fillForm(addressPage, formProvider(addressPage)), mode)
     }
 
   def onSubmit(ern: String, draftId: String, mode: Mode): Action[AnyContent] =

--- a/app/controllers/sections/dispatch/DispatchIndexController.scala
+++ b/app/controllers/sections/dispatch/DispatchIndexController.scala
@@ -21,6 +21,7 @@ import controllers.actions._
 import models.NormalMode
 import models.sections.info.movementScenario.MovementScenario.{CertifiedConsignee, TemporaryCertifiedConsignee}
 import navigation.DispatchNavigator
+import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.dispatch.DispatchSection
 import pages.sections.info.DestinationTypePage
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -42,13 +43,17 @@ class DispatchIndexController @Inject()(
   def onPageLoad(ern: String, draftId: String): Action[AnyContent] =
     authorisedDataRequest(ern, draftId) { implicit request =>
       if (DispatchSection.isCompleted || DispatchSection.status  == UpdateNeeded) {
-        Redirect(controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(ern, draftId))
+        Redirect(routes.DispatchCheckAnswersController.onPageLoad(ern, draftId))
       } else {
         withAnswer(DestinationTypePage) {
           case CertifiedConsignee | TemporaryCertifiedConsignee =>
-            Redirect(controllers.sections.dispatch.routes.DispatchUseConsignorDetailsController.onPageLoad(ern, draftId, NormalMode))
+            if(request.userAnswers.get(ConsignorAddressPage).nonEmpty) {
+              Redirect(routes.DispatchUseConsignorDetailsController.onPageLoad(ern, draftId, NormalMode))
+            } else {
+              Redirect(routes.DispatchBusinessNameController.onPageLoad(ern, draftId, NormalMode))
+            }
           case _ =>
-            Redirect(controllers.sections.dispatch.routes.DispatchWarehouseExciseController.onPageLoad(ern, draftId, NormalMode))
+            Redirect(routes.DispatchWarehouseExciseController.onPageLoad(ern, draftId, NormalMode))
         }
       }
     }

--- a/app/controllers/sections/dispatch/DispatchUseConsignorDetailsController.scala
+++ b/app/controllers/sections/dispatch/DispatchUseConsignorDetailsController.scala
@@ -22,7 +22,6 @@ import forms.sections.dispatch.DispatchUseConsignorDetailsFormProvider
 import models.requests.DataRequest
 import models.{Mode, NormalMode}
 import navigation.DispatchNavigator
-import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.dispatch.{DispatchAddressPage, DispatchBusinessNamePage, DispatchUseConsignorDetailsPage}
 import play.api.data.Form
 import play.api.i18n.MessagesApi

--- a/app/forms/AddressFormProvider.scala
+++ b/app/forms/AddressFormProvider.scala
@@ -65,8 +65,8 @@ class AddressFormProvider @Inject() extends Mappings {
   private def getExtraPostcodeValidationForPage(page: Page)(implicit request: DataRequest[_]): Seq[Constraint[String]] = {
 
     def niPostcode(isNi: Boolean): Seq[Constraint[String]] =
-      if(isNi) Seq(startsWith(XI_POSTCODE, "address.consignorAddress.error.mustStartWithBT")) else {
-        Seq(doesNotStartWith(XI_POSTCODE, "address.consignorAddress.error.mustNotStartWithBT"))
+      if(isNi) Seq(startsWith(XI_POSTCODE, "address.postcode.error.mustStartWithBT")) else {
+        Seq(doesNotStartWith(XI_POSTCODE, "address.postcode.error.mustNotStartWithBT"))
       }
 
     page match {

--- a/app/forms/AddressFormProvider.scala
+++ b/app/forms/AddressFormProvider.scala
@@ -16,11 +16,13 @@
 
 package forms
 
+import config.Constants
 import config.Constants.XI_POSTCODE
 import forms.mappings.Mappings
 import models.UserAddress
 import models.requests.DataRequest
 import pages.sections.consignor.ConsignorAddressPage
+import pages.sections.dispatch.{DispatchAddressPage, DispatchWarehouseExcisePage}
 import pages.{Page, QuestionPage}
 import play.api.data.Form
 import play.api.data.Forms.{mapping, optional}
@@ -58,15 +60,19 @@ class AddressFormProvider @Inject() extends Mappings {
         .verifying(regexpUnlessEmpty(XSS_REGEX, "address.postcode.error.invalid"))
         .verifying(getExtraPostcodeValidationForPage(page): _*)
     )(UserAddress.apply)(UserAddress.unapply)
-  )
+    )
 
   private def getExtraPostcodeValidationForPage(page: Page)(implicit request: DataRequest[_]): Seq[Constraint[String]] = {
-    page match {
-      case ConsignorAddressPage => if(request.isNorthernIrelandErn) {
-        Seq(startsWith(XI_POSTCODE, "address.consignorAddress.error.mustStartWithBT"))
-      } else {
+
+    def niPostcode(isNi: Boolean): Seq[Constraint[String]] =
+      if(isNi) Seq(startsWith(XI_POSTCODE, "address.consignorAddress.error.mustStartWithBT")) else {
         Seq(doesNotStartWith(XI_POSTCODE, "address.consignorAddress.error.mustNotStartWithBT"))
       }
+
+    page match {
+      case ConsignorAddressPage => niPostcode(request.isNorthernIrelandErn)
+      case DispatchAddressPage if request.userAnswers.get(DispatchWarehouseExcisePage).nonEmpty =>
+        niPostcode(request.userAnswers.get(DispatchWarehouseExcisePage).exists(_.startsWith(Constants.NI_PREFIX)))
       case _ => Seq.empty
     }
   }

--- a/app/models/requests/UserRequest.scala
+++ b/app/models/requests/UserRequest.scala
@@ -16,6 +16,7 @@
 
 package models.requests
 
+import config.Constants
 import models._
 import play.api.mvc.{Request, WrappedRequest}
 import utils.Logging
@@ -27,7 +28,7 @@ case class UserRequest[A](request: Request[A],
                           sessionId: String,
                           hasMultipleErns: Boolean) extends WrappedRequest[A](request) with Logging {
 
-  lazy val isNorthernIrelandErn: Boolean = ern.startsWith("XI")
+  lazy val isNorthernIrelandErn: Boolean = ern.startsWith(Constants.NI_PREFIX)
 
   lazy val userTypeFromErn: UserType = UserType(ern)
 

--- a/app/models/submitCreateMovement/TraderModel.scala
+++ b/app/models/submitCreateMovement/TraderModel.scala
@@ -82,20 +82,18 @@ object TraderModel extends ModelConstructorHelpers {
 
   def applyPlaceOfDispatch(implicit request: DataRequest[_]): Option[TraderModel] = {
     if (DispatchSection.canBeCompletedForTraderAndDestinationType) {
-      val useConsignorDetails: Boolean = mandatoryPage(DispatchUseConsignorDetailsPage)
-
-      if (useConsignorDetails) {
-        Some(applyConsignor.copy(traderExciseNumber = request.userAnswers.get(DispatchWarehouseExcisePage)))
+      val name = if(request.userAnswers.get(DispatchUseConsignorDetailsPage).contains(true)) {
+        Some(request.traderKnownFacts.traderName)
       } else {
-        val placeOfDispatchAddress: UserAddress = mandatoryPage(DispatchAddressPage)
-        Some(TraderModel(
-          traderExciseNumber = request.userAnswers.get(DispatchWarehouseExcisePage),
-          traderName = request.userAnswers.get(DispatchBusinessNamePage),
-          address = Some(AddressModel.fromUserAddress(placeOfDispatchAddress)),
-          vatNumber = None,
-          eoriNumber = None
-        ))
+        request.userAnswers.get(DispatchBusinessNamePage)
       }
+      Some(TraderModel(
+        traderExciseNumber = request.userAnswers.get(DispatchWarehouseExcisePage),
+        traderName = name,
+        address = Some(AddressModel.fromUserAddress(mandatoryPage(DispatchAddressPage))),
+        vatNumber = None,
+        eoriNumber = None
+      ))
     } else {
       None
     }

--- a/app/navigation/DispatchNavigator.scala
+++ b/app/navigation/DispatchNavigator.scala
@@ -16,9 +16,10 @@
 
 package navigation
 
-import controllers.routes
+import controllers.sections.dispatch.routes
 import models.{CheckMode, Mode, NormalMode, ReviewMode, UserAnswers}
 import pages.Page
+import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.dispatch._
 import play.api.mvc.Call
 
@@ -29,41 +30,45 @@ class DispatchNavigator @Inject() extends BaseNavigator {
   private val normalRoutes: Page => UserAnswers => Call = {
 
     case DispatchWarehouseExcisePage => (userAnswers: UserAnswers) =>
-      controllers.sections.dispatch.routes.DispatchUseConsignorDetailsController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
+      if(userAnswers.get(ConsignorAddressPage).nonEmpty) {
+        routes.DispatchUseConsignorDetailsController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
+      } else {
+        routes.DispatchBusinessNameController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
+      }
 
     case DispatchUseConsignorDetailsPage => (userAnswers: UserAnswers) =>
       userAnswers.get(DispatchUseConsignorDetailsPage) match {
-        case Some(true) => controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
-        case _ => controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
+        case Some(true) => routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
+        case _ => routes.DispatchBusinessNameController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
       }
 
     case DispatchBusinessNamePage => (userAnswers: UserAnswers) =>
-      controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
+      routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
 
     case DispatchAddressPage => (userAnswers: UserAnswers) =>
-      controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
 
     case DispatchCheckAnswersPage =>
-      (userAnswers: UserAnswers) => routes.DraftMovementController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      (userAnswers: UserAnswers) => controllers.routes.DraftMovementController.onPageLoad(userAnswers.ern, userAnswers.draftId)
 
     case _ =>
-      (userAnswers: UserAnswers) => controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      (userAnswers: UserAnswers) => routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
   }
 
   private[navigation] val reviewRouteMap: Page => UserAnswers => Call = {
     case _ =>
-      (userAnswers: UserAnswers) => routes.CheckYourAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      (userAnswers: UserAnswers) => controllers.routes.CheckYourAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
   }
 
   private val checkRoutes: Page => UserAnswers => Call = {
     case DispatchWarehouseExcisePage => (userAnswers: UserAnswers) =>
       if(userAnswers.get(DispatchAddressPage).isEmpty) {
-        controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, CheckMode)
+        routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, CheckMode)
       } else {
-        controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+        routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
       }
     case _ =>
-      (userAnswers: UserAnswers) => controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      (userAnswers: UserAnswers) => routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
   }
 
 

--- a/app/navigation/DispatchNavigator.scala
+++ b/app/navigation/DispatchNavigator.scala
@@ -56,6 +56,12 @@ class DispatchNavigator @Inject() extends BaseNavigator {
   }
 
   private val checkRoutes: Page => UserAnswers => Call = {
+    case DispatchWarehouseExcisePage => (userAnswers: UserAnswers) =>
+      if(userAnswers.get(DispatchAddressPage).isEmpty) {
+        controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, CheckMode)
+      } else {
+        controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      }
     case _ =>
       (userAnswers: UserAnswers) => controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
   }

--- a/app/navigation/DispatchNavigator.scala
+++ b/app/navigation/DispatchNavigator.scala
@@ -33,7 +33,7 @@ class DispatchNavigator @Inject() extends BaseNavigator {
 
     case DispatchUseConsignorDetailsPage => (userAnswers: UserAnswers) =>
       userAnswers.get(DispatchUseConsignorDetailsPage) match {
-        case Some(true) => controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+        case Some(true) => controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
         case _ => controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
       }
 

--- a/app/pages/sections/dispatch/DispatchSection.scala
+++ b/app/pages/sections/dispatch/DispatchSection.scala
@@ -37,21 +37,26 @@ case object DispatchSection extends Section[JsObject] {
     val hasDispatchWarehouseExciseOrCertifiedConsignee =
       request.userAnswers.get(DispatchWarehouseExcisePage).isDefined || isCertifiedConsigneeType
 
+    def checkRemainingPages: TaskListStatus = {
+      val remainingPages: Seq[Option[_]] = Seq(request.userAnswers.get(DispatchBusinessNamePage), request.userAnswers.get(DispatchAddressPage))
+      if (remainingPages.forall(_.isEmpty) && isCertifiedConsigneeType) {
+        NotStarted
+      } else if (remainingPages.forall(_.nonEmpty)) {
+        Completed
+      } else {
+        InProgress
+      }
+    }
+
     if (DispatchWarehouseExcisePage.isMovementSubmissionError) UpdateNeeded else {
-      hasDispatchWarehouseExciseOrCertifiedConsignee match {
-        case true => request.userAnswers.get(DispatchUseConsignorDetailsPage) match {
-          case Some(true) => Completed
-          case Some(false) =>
-            val remainingPages: Seq[Option[_]] = Seq(request.userAnswers.get(DispatchBusinessNamePage), request.userAnswers.get(DispatchAddressPage))
-            if (remainingPages.forall(_.nonEmpty)) {
-              Completed
-            } else {
-              InProgress
-            }
-          case None if isCertifiedConsigneeType => NotStarted
-          case None => InProgress
+      if(hasDispatchWarehouseExciseOrCertifiedConsignee) {
+        request.userAnswers.get(DispatchUseConsignorDetailsPage) match {
+          case Some(true) if request.userAnswers.get(DispatchAddressPage).nonEmpty => Completed
+          case Some(true) => InProgress
+          case _ => checkRemainingPages
         }
-        case false => NotStarted
+      } else {
+        NotStarted
       }
     }
   }

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
@@ -18,10 +18,8 @@ package viewmodels.checkAnswers.sections.dispatch
 
 import models.CheckMode
 import models.requests.DataRequest
-import pages.sections.consignor.ConsignorAddressPage
-import pages.sections.dispatch.{DispatchAddressPage, DispatchUseConsignorDetailsPage}
+import pages.sections.dispatch.DispatchAddressPage
 import play.api.i18n.Messages
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
@@ -20,6 +20,8 @@ import models.CheckMode
 import models.requests.DataRequest
 import pages.sections.dispatch.DispatchAddressPage
 import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.Aliases.{Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
@@ -27,20 +29,22 @@ import viewmodels.implicits._
 
 object DispatchAddressSummary {
 
-  def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
-    request.userAnswers.get(DispatchAddressPage).map {
-      answer =>
-        SummaryListRowViewModel(
-          key = "address.dispatchAddress.checkYourAnswersLabel",
-          value = ValueViewModel(answer.toCheckYourAnswersFormat),
-          actions = Seq(
-            ActionItemViewModel(
-              content = "site.change",
-              href = controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(request.ern, request.draftId, CheckMode).url,
-              id = "changeDispatchAddress"
-            ).withVisuallyHiddenText(messages("address.dispatchAddress.change.hidden"))
-          )
-        )
+  def row()(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
+    request.userAnswers.get(DispatchAddressPage) match {
+      case Some(address) => renderRow(ValueViewModel(address.toCheckYourAnswersFormat))
+      case _ => renderRow(ValueViewModel(Text(messages("site.notProvided"))))
     }
-  }
+
+  private def renderRow(value: Value)(implicit request: DataRequest[_], messages: Messages) =
+    SummaryListRowViewModel(
+      key = "address.dispatchAddress.checkYourAnswersLabel",
+      value = value,
+      actions = Seq(
+        ActionItemViewModel(
+          content = "site.change",
+          href = controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(request.ern, request.draftId, CheckMode).url,
+          id = "changeDispatchAddress"
+        ).withVisuallyHiddenText(messages("address.dispatchAddress.change.hidden"))
+      )
+    )
 }

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
@@ -20,7 +20,6 @@ import models.CheckMode
 import models.requests.DataRequest
 import pages.sections.dispatch.DispatchAddressPage
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummary.scala
@@ -30,36 +30,19 @@ import viewmodels.implicits._
 object DispatchAddressSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
-    request.userAnswers.get(DispatchUseConsignorDetailsPage).flatMap {
-      case true =>
-        request.userAnswers.get(ConsignorAddressPage) match {
-          case Some(answer) =>
-            Some(SummaryListRowViewModel(
-              key = "address.dispatchAddress.checkYourAnswersLabel",
-              value = ValueViewModel(answer.toCheckYourAnswersFormat),
-              actions = Seq()
-            ))
-          case None => Some(SummaryListRowViewModel(
-            key = "address.dispatchAddress.checkYourAnswersLabel",
-            value = ValueViewModel(Text(messages("address.dispatchAddress.checkYourAnswers.consignorNotComplete"))),
-            actions = Seq()
-          ))
-        }
-      case false =>
-        request.userAnswers.get(DispatchAddressPage).map {
-          answer =>
-            SummaryListRowViewModel(
-              key = "address.dispatchAddress.checkYourAnswersLabel",
-              value = ValueViewModel(answer.toCheckYourAnswersFormat),
-              actions = Seq(
-                ActionItemViewModel(
-                  content = "site.change",
-                  href = controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(request.ern, request.draftId, CheckMode).url,
-                  id = "changeDispatchAddress"
-                ).withVisuallyHiddenText(messages("address.dispatchAddress.change.hidden"))
-              )
-            )
-        }
+    request.userAnswers.get(DispatchAddressPage).map {
+      answer =>
+        SummaryListRowViewModel(
+          key = "address.dispatchAddress.checkYourAnswersLabel",
+          value = ValueViewModel(answer.toCheckYourAnswersFormat),
+          actions = Seq(
+            ActionItemViewModel(
+              content = "site.change",
+              href = controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(request.ern, request.draftId, CheckMode).url,
+              id = "changeDispatchAddress"
+            ).withVisuallyHiddenText(messages("address.dispatchAddress.change.hidden"))
+          )
+        )
     }
   }
 }

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchBusinessNameSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchBusinessNameSummary.scala
@@ -28,13 +28,13 @@ import viewmodels.implicits._
 object DispatchBusinessNameSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
-    request.userAnswers.get(DispatchUseConsignorDetailsPage).flatMap {
-      case true => Some(SummaryListRowViewModel(
+    request.userAnswers.get(DispatchUseConsignorDetailsPage) match {
+      case Some(true) => Some(SummaryListRowViewModel(
         key = "dispatchBusinessName.checkYourAnswersLabel",
         value = ValueViewModel(HtmlFormat.escape(request.traderKnownFacts.traderName).toString),
         actions = Seq()
       ))
-      case false =>
+      case _ =>
         request.userAnswers.get(DispatchBusinessNamePage).map {
           answer =>
             SummaryListRowViewModel(

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchBusinessNameSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchBusinessNameSummary.scala
@@ -27,28 +27,26 @@ import viewmodels.implicits._
 
 object DispatchBusinessNameSummary {
 
-  def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
+  def row()(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
     request.userAnswers.get(DispatchUseConsignorDetailsPage) match {
-      case Some(true) => Some(SummaryListRowViewModel(
-        key = "dispatchBusinessName.checkYourAnswersLabel",
-        value = ValueViewModel(HtmlFormat.escape(request.traderKnownFacts.traderName).toString),
-        actions = Seq()
-      ))
+      case Some(true) => renderRow(request.traderKnownFacts.traderName, withChangeLink = false)
       case _ =>
-        request.userAnswers.get(DispatchBusinessNamePage).map {
-          answer =>
-            SummaryListRowViewModel(
-              key = "dispatchBusinessName.checkYourAnswersLabel",
-              value = ValueViewModel(HtmlFormat.escape(answer).toString),
-              actions = Seq(
-                ActionItemViewModel(
-                  content = "site.change",
-                  href = controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(request.ern, request.draftId, CheckMode).url,
-                  id = "changeDispatchBusinessName"
-                ).withVisuallyHiddenText(messages("dispatchBusinessName.change.hidden"))
-              )
-            )
+        request.userAnswers.get(DispatchBusinessNamePage) match {
+          case Some(name) => renderRow(name)
+          case _ => renderRow(messages("site.notProvided"))
         }
     }
-  }
+
+  private def renderRow(value: String, withChangeLink: Boolean = true)(implicit request: DataRequest[_], messages: Messages) =
+    SummaryListRowViewModel(
+      key = "dispatchBusinessName.checkYourAnswersLabel",
+      value = ValueViewModel(HtmlFormat.escape(value).toString),
+      actions = if (!withChangeLink) Seq() else Seq(
+        ActionItemViewModel(
+          content = "site.change",
+          href = controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(request.ern, request.draftId, CheckMode).url,
+          id = "changeDispatchBusinessName"
+        ).withVisuallyHiddenText(messages("dispatchBusinessName.change.hidden"))
+      )
+    )
 }

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelper.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelper.scala
@@ -29,8 +29,8 @@ class DispatchCheckAnswersHelper @Inject()(dispatchWarehouseExciseSummary: Dispa
     SummaryListViewModel(
       rows = Seq(
         DispatchUseConsignorDetailsSummary.row(),
-        DispatchBusinessNameSummary.row(),
         dispatchWarehouseExciseSummary.row(),
+        DispatchBusinessNameSummary.row(),
         DispatchAddressSummary.row()
       ).flatten
     ).withCssClass("govuk-!-margin-bottom-9")

--- a/app/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelper.scala
+++ b/app/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelper.scala
@@ -30,8 +30,8 @@ class DispatchCheckAnswersHelper @Inject()(dispatchWarehouseExciseSummary: Dispa
       rows = Seq(
         DispatchUseConsignorDetailsSummary.row(),
         dispatchWarehouseExciseSummary.row(),
-        DispatchBusinessNameSummary.row(),
-        DispatchAddressSummary.row()
+        Some(DispatchBusinessNameSummary.row()),
+        Some(DispatchAddressSummary.row())
       ).flatten
     ).withCssClass("govuk-!-margin-bottom-9")
 }

--- a/conf/messages
+++ b/conf/messages
@@ -256,7 +256,6 @@ address.dispatchAddress.title = Enter the place of dispatch address
 address.dispatchAddress.heading = Enter the place of dispatch address
 address.dispatchAddress.subheading = Place of dispatch information
 address.dispatchAddress.checkYourAnswersLabel = Address
-address.dispatchAddress.checkYourAnswers.consignorNotComplete = Consignor section not complete
 address.dispatchAddress.change.hidden = Address
 
 address.transportArrangerAddress.3.title = Enter the goods owner’s business address

--- a/conf/messages
+++ b/conf/messages
@@ -238,8 +238,6 @@ localReferenceNumber.new.change.hidden = Unique reference (LRN)
 address.consignorAddress.title = Enter the consignor’s address
 address.consignorAddress.heading = Enter the consignor’s address
 address.consignorAddress.subheading = Consignor information
-address.consignorAddress.error.mustStartWithBT = Postcode must begin with BT
-address.consignorAddress.error.mustNotStartWithBT = Postcode must not begin with BT
 
 address.consigneeAddress.title = Enter the consignee’s address
 address.consigneeAddress.heading = Enter the consignee’s address
@@ -300,6 +298,8 @@ address.postcode.error.required = Enter a postcode
 address.postcode.error.length = Enter a postcode up to 10 characters
 address.postcode.error.character = Postcode must contain letters or numbers
 address.postcode.error.invalid = Postcode must not contain < and > and : and ;
+address.postcode.error.mustStartWithBT = Postcode must begin with BT
+address.postcode.error.mustNotStartWithBT = Postcode must not begin with BT
 
 consignorPaidTemporaryAuthorisationCode.title = Enter the consignor’s Paid Temporary Authorisation (PTA) code
 consignorPaidTemporaryAuthorisationCode.heading = Enter the consignor’s Paid Temporary Authorisation (PTA) code

--- a/test-utils/fixtures/messages/sections/dispatch/DispatchCheckAnswersMessages.scala
+++ b/test-utils/fixtures/messages/sections/dispatch/DispatchCheckAnswersMessages.scala
@@ -27,7 +27,6 @@ object DispatchCheckAnswersMessages {
     val traderNameChangeHidden = "Trader name"
     val addressLabel: String = "Address"
     val ern: String = "Excise ID (ERN)"
-    val consignorSectionNotComplete: String = "Consignor section not complete"
     val addressChangeHidden: String = "Address"
     val dispatchWarehouseInvalidOrMissingOnSeedError = "The excise ID for the tax warehouse of dispatch is not valid"
     val dispatchWarehouseInvalidError = "The excise ID for the tax warehouse of dispatch is not valid"

--- a/test-utils/fixtures/messages/sections/guarantor/GuarantorNameMessages.scala
+++ b/test-utils/fixtures/messages/sections/guarantor/GuarantorNameMessages.scala
@@ -39,7 +39,6 @@ object GuarantorNameMessages {
     val cyaChangeHidden = "business name"
 
     val consigneeNameNotProvided = "Consignee section not complete"
-    val consignorNameNotProvided = "Consignor section not complete"
   }
 
   object English extends ViewMessages with BaseEnglish

--- a/test/controllers/sections/dispatch/DispatchAddressControllerSpec.scala
+++ b/test/controllers/sections/dispatch/DispatchAddressControllerSpec.scala
@@ -24,8 +24,9 @@ import forms.AddressFormProvider
 import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAddress, UserAnswers}
 import navigation.FakeNavigators.FakeDispatchNavigator
+import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.destination.DestinationAddressPage
-import pages.sections.dispatch.DispatchAddressPage
+import pages.sections.dispatch.{DispatchAddressPage, DispatchUseConsignorDetailsPage}
 import play.api.data.Form
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -69,6 +70,39 @@ class DispatchAddressControllerSpec extends SpecBase with MockUserAnswersService
       status(result) mustEqual OK
       contentAsString(result) mustEqual view(
         form = form,
+        addressPage = DispatchAddressPage,
+        call = dispatchAddressOnSubmit,
+        headingKey = Some("dispatchAddress")
+      )(dataRequest(request), messages(request)).toString
+    }
+
+    "must fill the form with data from ConisgnorAddress when UseConsignor is true and no Dispatch address exists" in new Fixture(Some(
+      emptyUserAnswers
+        .set(DispatchUseConsignorDetailsPage, true)
+        .set(ConsignorAddressPage, testUserAddress.copy(street = "Consignor"))
+    )) {
+      val result = testController.onPageLoad(testErn, testDraftId, NormalMode)(request)
+
+      status(result) mustEqual OK
+      contentAsString(result) mustEqual view(
+        form = form.fill(testUserAddress.copy(street = "Consignor")),
+        addressPage = DispatchAddressPage,
+        call = dispatchAddressOnSubmit,
+        headingKey = Some("dispatchAddress")
+      )(dataRequest(request), messages(request)).toString
+    }
+
+    "must fill the form with data from DispatchAddress when UseConsignor is true and Dispatch address exists" in new Fixture(Some(
+      emptyUserAnswers
+        .set(DispatchUseConsignorDetailsPage, true)
+        .set(ConsignorAddressPage, testUserAddress.copy(street = "Consignor"))
+        .set(DispatchAddressPage, testUserAddress.copy(street = "Dispatch"))
+    )) {
+      val result = testController.onPageLoad(testErn, testDraftId, NormalMode)(request)
+
+      status(result) mustEqual OK
+      contentAsString(result) mustEqual view(
+        form = form.fill(testUserAddress.copy(street = "Dispatch")),
         addressPage = DispatchAddressPage,
         call = dispatchAddressOnSubmit,
         headingKey = Some("dispatchAddress")

--- a/test/controllers/sections/dispatch/DispatchIndexControllerSpec.scala
+++ b/test/controllers/sections/dispatch/DispatchIndexControllerSpec.scala
@@ -86,15 +86,33 @@ class DispatchIndexControllerSpec extends SpecBase with MockUserAnswersService w
 
       Seq(CertifiedConsignee, TemporaryCertifiedConsignee).foreach { destinationType =>
 
-        s"when $destinationType must redirect to the DispatchUseConsignorDetailsController" in new Fixture(Some(emptyUserAnswers
-          .set(DestinationTypePage, destinationType)
-        )) {
+        "when ConsignorAddress exists" - {
 
-          val result = testController.onPageLoad(testErn, testDraftId)(request)
+          s"when $destinationType must redirect to the DispatchUseConsignorDetailsController" in new Fixture(Some(emptyUserAnswers
+            .set(DestinationTypePage, destinationType)
+            .set(ConsignorAddressPage, testUserAddress)
+          )) {
 
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result) mustBe
-            Some(controllers.sections.dispatch.routes.DispatchUseConsignorDetailsController.onPageLoad(testErn, testDraftId, NormalMode).url)
+            val result = testController.onPageLoad(testErn, testDraftId)(request)
+
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result) mustBe
+              Some(controllers.sections.dispatch.routes.DispatchUseConsignorDetailsController.onPageLoad(testErn, testDraftId, NormalMode).url)
+          }
+        }
+
+        "when ConsignorAddress DOES NOT exist" - {
+
+          s"when $destinationType must redirect to the DispatchBusinessNameController" in new Fixture(Some(emptyUserAnswers
+            .set(DestinationTypePage, destinationType)
+          )) {
+
+            val result = testController.onPageLoad(testErn, testDraftId)(request)
+
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result) mustBe
+              Some(controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode).url)
+          }
         }
       }
 

--- a/test/controllers/sections/dispatch/DispatchIndexControllerSpec.scala
+++ b/test/controllers/sections/dispatch/DispatchIndexControllerSpec.scala
@@ -24,7 +24,7 @@ import models.sections.info.movementScenario.MovementScenario.{CertifiedConsigne
 import models.{NormalMode, UserAnswers}
 import navigation.FakeNavigators.FakeDispatchNavigator
 import pages.sections.consignor.ConsignorAddressPage
-import pages.sections.dispatch.{DispatchUseConsignorDetailsPage, DispatchWarehouseExcisePage}
+import pages.sections.dispatch.{DispatchAddressPage, DispatchUseConsignorDetailsPage, DispatchWarehouseExcisePage}
 import pages.sections.info.DestinationTypePage
 import play.api.http.Status.SEE_OTHER
 import play.api.mvc.Result
@@ -56,7 +56,7 @@ class DispatchIndexControllerSpec extends SpecBase with MockUserAnswersService w
           Some(emptyUserAnswers
             .set(DispatchWarehouseExcisePage, "beans")
             .set(DispatchUseConsignorDetailsPage, true)
-            .set(ConsignorAddressPage, testUserAddress)
+            .set(DispatchAddressPage, testUserAddress)
             .copy(submissionFailures = Seq(dispatchWarehouseInvalidOrMissingOnSeedError))
           )) {
 
@@ -72,7 +72,7 @@ class DispatchIndexControllerSpec extends SpecBase with MockUserAnswersService w
       "must redirect to the CYA controller" in new Fixture(Some(emptyUserAnswers
         .set(DispatchWarehouseExcisePage, "beans")
         .set(DispatchUseConsignorDetailsPage, true)
-        .set(ConsignorAddressPage, testUserAddress)
+        .set(DispatchAddressPage, testUserAddress)
       )) {
 
         val result = testController.onPageLoad(testErn, testDraftId)(request)

--- a/test/controllers/sections/dispatch/DispatchUseConsignorDetailsControllerSpec.scala
+++ b/test/controllers/sections/dispatch/DispatchUseConsignorDetailsControllerSpec.scala
@@ -22,7 +22,6 @@ import forms.sections.dispatch.DispatchUseConsignorDetailsFormProvider
 import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.FakeNavigators.FakeDispatchNavigator
-import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.dispatch.{DispatchAddressPage, DispatchBusinessNamePage, DispatchUseConsignorDetailsPage}
 import play.api.data.Form
 import play.api.mvc.Call

--- a/test/controllers/sections/dispatch/DispatchUseConsignorDetailsControllerSpec.scala
+++ b/test/controllers/sections/dispatch/DispatchUseConsignorDetailsControllerSpec.scala
@@ -81,18 +81,11 @@ class DispatchUseConsignorDetailsControllerSpec extends SpecBase with MockUserAn
     }
 
     "onSubmit" - {
-      "must redirect to the next page when valid data is submitted - data is new (copying consignor address)" in new Fixture(Some(
-        emptyUserAnswers
-          .set(ConsignorAddressPage, testUserAddress)
-          .set(DispatchBusinessNamePage, testBusinessName)
-      )) {
+      "must redirect to the next page when valid data is submitted - data is new" in new Fixture(Some(emptyUserAnswers)) {
 
-        val expectedSavedAnswers = optUserAnswers.get
-          .set(DispatchUseConsignorDetailsPage, true)
-          .set(DispatchAddressPage, testUserAddress)
-          .remove(DispatchBusinessNamePage)
+        val expectedSavedAnswers = emptyUserAnswers.set(DispatchUseConsignorDetailsPage, true)
 
-        MockUserAnswersService.set(expectedSavedAnswers).returns(Future.successful(emptyUserAnswers))
+        MockUserAnswersService.set(expectedSavedAnswers).returns(Future.successful(expectedSavedAnswers))
 
         val req = FakeRequest(POST, dispatchUseConsignorDetailsRoute).withFormUrlEncodedBody(("value", "true"))
         val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)
@@ -101,10 +94,17 @@ class DispatchUseConsignorDetailsControllerSpec extends SpecBase with MockUserAn
         redirectLocation(result).value mustEqual testOnwardRoute.url
       }
 
-      "must redirect to the next page when valid data is submitted - data has changed" in new Fixture(
-        Some(emptyUserAnswers.set(DispatchUseConsignorDetailsPage, true))
+      "must redirect to the next page when valid data is submitted - data has changed (removing BusinessName and DispatchAddress)" in new Fixture(
+        Some(emptyUserAnswers
+          .set(DispatchUseConsignorDetailsPage, true)
+          .set(DispatchAddressPage, testUserAddress)
+          .set(DispatchBusinessNamePage, testBusinessName)
+        )
       ) {
-        MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
+
+        val expectedAnswers = emptyUserAnswers.set(DispatchUseConsignorDetailsPage, false)
+
+        MockUserAnswersService.set(expectedAnswers).returns(Future.successful(expectedAnswers))
 
         val req = FakeRequest(POST, dispatchUseConsignorDetailsRoute).withFormUrlEncodedBody(("value", "false"))
         val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)

--- a/test/controllers/sections/dispatch/DispatchUseConsignorDetailsControllerSpec.scala
+++ b/test/controllers/sections/dispatch/DispatchUseConsignorDetailsControllerSpec.scala
@@ -22,7 +22,8 @@ import forms.sections.dispatch.DispatchUseConsignorDetailsFormProvider
 import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.FakeNavigators.FakeDispatchNavigator
-import pages.sections.dispatch.DispatchUseConsignorDetailsPage
+import pages.sections.consignor.ConsignorAddressPage
+import pages.sections.dispatch.{DispatchAddressPage, DispatchBusinessNamePage, DispatchUseConsignorDetailsPage}
 import play.api.data.Form
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -42,7 +43,7 @@ class DispatchUseConsignorDetailsControllerSpec extends SpecBase with MockUserAn
   lazy val dispatchUseConsignorDetailsSubmitAction: Call =
     routes.DispatchUseConsignorDetailsController.onSubmit(testErn, testDraftId, NormalMode)
 
-  class Fixture(optUserAnswers: Option[UserAnswers] = Some(emptyUserAnswers)) {
+  class Fixture(val optUserAnswers: Option[UserAnswers] = Some(emptyUserAnswers)) {
     val request = FakeRequest(GET, dispatchUseConsignorDetailsRoute)
 
     lazy val testController = new DispatchUseConsignorDetailsController(
@@ -80,8 +81,18 @@ class DispatchUseConsignorDetailsControllerSpec extends SpecBase with MockUserAn
     }
 
     "onSubmit" - {
-      "must redirect to the next page when valid data is submitted - data is new" in new Fixture(Some(emptyUserAnswers)) {
-        MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
+      "must redirect to the next page when valid data is submitted - data is new (copying consignor address)" in new Fixture(Some(
+        emptyUserAnswers
+          .set(ConsignorAddressPage, testUserAddress)
+          .set(DispatchBusinessNamePage, testBusinessName)
+      )) {
+
+        val expectedSavedAnswers = optUserAnswers.get
+          .set(DispatchUseConsignorDetailsPage, true)
+          .set(DispatchAddressPage, testUserAddress)
+          .remove(DispatchBusinessNamePage)
+
+        MockUserAnswersService.set(expectedSavedAnswers).returns(Future.successful(emptyUserAnswers))
 
         val req = FakeRequest(POST, dispatchUseConsignorDetailsRoute).withFormUrlEncodedBody(("value", "true"))
         val result = testController.onSubmit(testErn, testDraftId, NormalMode)(req)

--- a/test/controllers/sections/items/ItemExciseProductCodeControllerSpec.scala
+++ b/test/controllers/sections/items/ItemExciseProductCodeControllerSpec.scala
@@ -161,7 +161,12 @@ class ItemExciseProductCodeControllerSpec extends SpecBase
           emptyUserAnswers
             .set(ItemExciseProductCodePage(testIndex1), testEpcTobacco)
             .set(ItemExciseProductCodePage(testIndex2), testExciseProductCodeB000.code)
-            .copy(submissionFailures = Seq(itemQuantityFailure(1), itemQuantityFailure(2).copy(originalAttributeValue = Some("UPDATED")), movementSubmissionFailure))
+            .copy(submissionFailures =
+              Seq(
+                itemQuantityFailure(1),
+                itemQuantityFailure(2).copy(originalAttributeValue = Some("UPDATED")), movementSubmissionFailure
+              )
+            )
         )) {
           MockGetExciseProductCodesService.getExciseProductCodes().returns(Future.successful(sampleEPCs))
 

--- a/test/forms/AddressFormProviderSpec.scala
+++ b/test/forms/AddressFormProviderSpec.scala
@@ -42,8 +42,8 @@ class AddressFormProviderSpec extends SpecBase with FieldBehaviours with UserAdd
 
   val postcodeField = testPostcodeParameters.fieldName
 
-  val notBTPostcodeKey = "address.consignorAddress.error.mustNotStartWithBT"
-  val mustBeBTPostcodeKey = "address.consignorAddress.error.mustStartWithBT"
+  val notBTPostcodeKey = "address.postcode.error.mustNotStartWithBT"
+  val mustBeBTPostcodeKey = "address.postcode.error.mustStartWithBT"
 
   def formAnswersMap(updateField: Option[String] = None,
                      updateAnswer: Option[String] = None): Map[String, String] = {

--- a/test/models/submitCreateMovement/TraderModelSpec.scala
+++ b/test/models/submitCreateMovement/TraderModelSpec.scala
@@ -218,12 +218,14 @@ class TraderModelSpec extends SpecBase {
               fakeRequest,
               emptyUserAnswers
                 .set(DispatchUseConsignorDetailsPage, true)
-                .set(ConsignorAddressPage, testUserAddress.copy(street = "consignor street"))
+                .set(DispatchAddressPage, testUserAddress.copy(street = "dispatch street"))
                 .set(DispatchWarehouseExcisePage, "dispatch ern"),
               ern
             )
 
-            TraderModel.applyPlaceOfDispatch mustBe Some(consignorTrader.copy(traderExciseNumber = Some("dispatch ern")))
+            TraderModel.applyPlaceOfDispatch mustBe Some(placeOfDispatchTrader.copy(
+              traderName = consignorTrader.traderName
+            ))
         }
       }
       "when __WK and use consignor details = false" in {

--- a/test/navigation/DispatchNavigatorSpec.scala
+++ b/test/navigation/DispatchNavigatorSpec.scala
@@ -20,6 +20,7 @@ import base.SpecBase
 import controllers.routes
 import models.{CheckMode, NormalMode, ReviewMode}
 import pages.Page
+import pages.sections.consignor.ConsignorAddressPage
 import pages.sections.dispatch._
 
 class DispatchNavigatorSpec extends SpecBase {
@@ -36,9 +37,23 @@ class DispatchNavigatorSpec extends SpecBase {
 
       "for the DispatchWarehouseExcisePage" - {
 
-        "must go to DispatchConsignorDetails page" in {
-          navigator.nextPage(DispatchWarehouseExcisePage, NormalMode, emptyUserAnswers) mustBe
-            controllers.sections.dispatch.routes.DispatchUseConsignorDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+        "when there is a ConsignorAddress available to pre-populate" - {
+
+          "must go to DispatchConsignorDetails page" in {
+
+            val userAnswers = emptyUserAnswers.set(ConsignorAddressPage, testUserAddress)
+
+            navigator.nextPage(DispatchWarehouseExcisePage, NormalMode, userAnswers) mustBe
+              controllers.sections.dispatch.routes.DispatchUseConsignorDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+          }
+        }
+
+        "when there is NO ConsignorAddress" - {
+
+          "must go to DispatchBusinessName page" in {
+            navigator.nextPage(DispatchWarehouseExcisePage, NormalMode, emptyUserAnswers) mustBe
+              controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
+          }
         }
       }
 

--- a/test/navigation/DispatchNavigatorSpec.scala
+++ b/test/navigation/DispatchNavigatorSpec.scala
@@ -39,7 +39,7 @@ class DispatchNavigatorSpec extends SpecBase {
 
         "when there is a ConsignorAddress available to pre-populate" - {
 
-          "must go to DispatchConsignorDetails page" in {
+          "must go to DispatchUseConsignorDetails page" in {
 
             val userAnswers = emptyUserAnswers.set(ConsignorAddressPage, testUserAddress)
 

--- a/test/navigation/DispatchNavigatorSpec.scala
+++ b/test/navigation/DispatchNavigatorSpec.scala
@@ -46,12 +46,12 @@ class DispatchNavigatorSpec extends SpecBase {
 
         "when using consignor details" - {
 
-          "must go to DispatchCheckYourAnswers page" in {
+          "must go to DispatchAddressPage page" in {
 
             val userAnswers = emptyUserAnswers.set(DispatchUseConsignorDetailsPage, true)
 
             navigator.nextPage(DispatchUseConsignorDetailsPage, NormalMode, userAnswers) mustBe
-              controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(emptyUserAnswers.ern, emptyUserAnswers.draftId)
+              controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(emptyUserAnswers.ern, emptyUserAnswers.draftId, NormalMode)
           }
         }
 

--- a/test/navigation/DispatchNavigatorSpec.scala
+++ b/test/navigation/DispatchNavigatorSpec.scala
@@ -99,9 +99,32 @@ class DispatchNavigatorSpec extends SpecBase {
 
     "in Check mode" - {
 
+      "for the DispatchWarehouseErn page" - {
+
+        "when a DispatchAddress exists" - {
+
+          "must go to CYA page" in {
+
+            val userAnswers = emptyUserAnswers.set(DispatchAddressPage, testUserAddress)
+
+            navigator.nextPage(DispatchWarehouseExcisePage, CheckMode, userAnswers) mustBe
+              controllers.sections.dispatch.routes.DispatchCheckAnswersController.onPageLoad(emptyUserAnswers.ern, emptyUserAnswers.draftId)
+          }
+        }
+
+        "when a DispatchAddress DOES NOT exist" - {
+
+          "must go to DispatchAddress page" in {
+
+            navigator.nextPage(DispatchWarehouseExcisePage, CheckMode, emptyUserAnswers) mustBe
+              controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(emptyUserAnswers.ern, emptyUserAnswers.draftId, CheckMode)
+          }
+        }
+      }
+
       "for the DispatchBusinessNamePage" - {
 
-        "must go to DispatchAddress page" in {
+        "must go to CYA page" in {
 
           val userAnswers = emptyUserAnswers.set(DispatchBusinessNamePage, "TestBusinessName")
 

--- a/test/pages/sections/dispatch/DispatchSectionSpec.scala
+++ b/test/pages/sections/dispatch/DispatchSectionSpec.scala
@@ -30,10 +30,11 @@ class DispatchSectionSpec extends SpecBase with MovementSubmissionFailureFixture
 
     "must return true" - {
 
-      "when Consignor details question is 'yes' and Consignor section is completed" in {
+      "when Consignor details question is 'yes' and Address is provided" in {
 
         implicit val dr: DataRequest[_] = dataRequest(FakeRequest(), emptyUserAnswers
           .set(DispatchWarehouseExcisePage, "beans")
+          .set(DispatchAddressPage, testUserAddress)
           .set(DispatchUseConsignorDetailsPage, true)
         )
         DispatchSection.isCompleted mustBe true
@@ -83,6 +84,16 @@ class DispatchSectionSpec extends SpecBase with MovementSubmissionFailureFixture
         implicit val dr: DataRequest[_] = dataRequest(FakeRequest(), emptyUserAnswers
           .set(DispatchWarehouseExcisePage, "beans")
           .set(DispatchUseConsignorDetailsPage, false)
+          .set(DispatchBusinessNamePage, "beans")
+        )
+        DispatchSection.isCompleted mustBe false
+      }
+
+      "when Consignor details question is 'Yes' and DispatchAddress is missing" in {
+
+        implicit val dr: DataRequest[_] = dataRequest(FakeRequest(), emptyUserAnswers
+          .set(DispatchWarehouseExcisePage, "beans")
+          .set(DispatchUseConsignorDetailsPage, true)
           .set(DispatchBusinessNamePage, "beans")
         )
         DispatchSection.isCompleted mustBe false

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummarySpec.scala
@@ -25,6 +25,9 @@ import org.scalatest.matchers.must.Matchers
 import pages.sections.dispatch.DispatchAddressPage
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
+import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow, Value}
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
@@ -32,19 +35,32 @@ class DispatchAddressSummarySpec extends SpecBase with Matchers with UserAddress
 
   class Test(userAnswers: UserAnswers) {
     implicit lazy val request: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
+
+    def expectedRow(value: Value)(implicit messagesForLanguage: DispatchCheckAnswersMessages.ViewMessages): SummaryListRow =
+      SummaryListRowViewModel(
+        key = Key(Text(messagesForLanguage.addressLabel)),
+        value = value,
+        actions = Seq(
+          ActionItemViewModel(
+            content = Text(messagesForLanguage.change),
+            href = controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(testErn, testDraftId, CheckMode).url,
+            id = "changeDispatchAddress"
+          ).withVisuallyHiddenText(messagesForLanguage.addressChangeHidden)
+        )
+      )
   }
 
   "DispatchBusinessAddressSummary" - {
 
-    Seq(DispatchCheckAnswersMessages.English).foreach { messagesForLanguage =>
+    Seq(DispatchCheckAnswersMessages.English).foreach { implicit messagesForLanguage =>
 
       s"when being rendered in lang code of '${messagesForLanguage.lang.code}'" - {
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        "must output no row" - {
-          "when there's no answer for DispatchUseConsignorDetailsPage" in new Test(emptyUserAnswers) {
-            DispatchAddressSummary.row() mustBe None
+        "must output 'Not Provided' row" - {
+          "when there's no answer for DispatchAddressPage" in new Test(emptyUserAnswers) {
+            DispatchAddressSummary.row() mustBe expectedRow(ValueViewModel(Text(messagesForLanguage.notProvided)))
           }
         }
 
@@ -53,20 +69,7 @@ class DispatchAddressSummarySpec extends SpecBase with Matchers with UserAddress
           "when there's an answer for DispatchAddressPage" in new Test(
             emptyUserAnswers.set(DispatchAddressPage, userAddressModelMax)
           ) {
-            DispatchAddressSummary.row() mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.addressLabel,
-                  value = ValueViewModel(userAddressModelMax.toCheckYourAnswersFormat),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = controllers.sections.dispatch.routes.DispatchAddressController.onPageLoad(testErn, testDraftId, CheckMode).url,
-                      id = "changeDispatchAddress"
-                    ).withVisuallyHiddenText(messagesForLanguage.addressChangeHidden)
-                  )
-                )
-              )
+            DispatchAddressSummary.row() mustBe expectedRow(ValueViewModel(userAddressModelMax.toCheckYourAnswersFormat))
           }
         }
       }

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummarySpec.scala
@@ -27,9 +27,8 @@ import play.api.i18n.Messages
 import play.api.test.FakeRequest
 import uk.gov.hmrc.govukfrontend.views.Aliases.Value
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow, Value}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
 import viewmodels.govuk.summarylist._
-import viewmodels.implicits._
 
 class DispatchAddressSummarySpec extends SpecBase with Matchers with UserAddressFixtures {
 

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchAddressSummarySpec.scala
@@ -22,8 +22,7 @@ import fixtures.messages.sections.dispatch.DispatchCheckAnswersMessages
 import models.requests.DataRequest
 import models.{CheckMode, UserAnswers}
 import org.scalatest.matchers.must.Matchers
-import pages.sections.consignor.ConsignorAddressPage
-import pages.sections.dispatch.{DispatchAddressPage, DispatchUseConsignorDetailsPage}
+import pages.sections.dispatch.DispatchAddressPage
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
 import viewmodels.govuk.summarylist._
@@ -47,19 +46,12 @@ class DispatchAddressSummarySpec extends SpecBase with Matchers with UserAddress
           "when there's no answer for DispatchUseConsignorDetailsPage" in new Test(emptyUserAnswers) {
             DispatchAddressSummary.row() mustBe None
           }
-          "when DispatchUseConsignorDetailsPage is false and there's no answer for DispatchAddressPage" in new Test(
-            emptyUserAnswers.set(DispatchUseConsignorDetailsPage, false)
-          ) {
-            DispatchAddressSummary.row() mustBe None
-          }
         }
 
         s"must output the expected row for DispatchAddress" - {
 
-          "when DispatchUseConsignorDetailsPage is false and there's an answer for DispatchAddressPage" in new Test(
-            emptyUserAnswers
-              .set(DispatchUseConsignorDetailsPage, false)
-              .set(DispatchAddressPage, userAddressModelMax)
+          "when there's an answer for DispatchAddressPage" in new Test(
+            emptyUserAnswers.set(DispatchAddressPage, userAddressModelMax)
           ) {
             DispatchAddressSummary.row() mustBe
               Some(
@@ -73,35 +65,6 @@ class DispatchAddressSummarySpec extends SpecBase with Matchers with UserAddress
                       id = "changeDispatchAddress"
                     ).withVisuallyHiddenText(messagesForLanguage.addressChangeHidden)
                   )
-                )
-              )
-          }
-
-          "when DispatchUseConsignorDetailsPage is true and there's an answer for ConsignorAddressPage" in new Test(
-            emptyUserAnswers
-              .set(DispatchUseConsignorDetailsPage, true)
-              .set(ConsignorAddressPage, userAddressModelMax)
-          ) {
-            DispatchAddressSummary.row() mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.addressLabel,
-                  value = ValueViewModel(userAddressModelMax.toCheckYourAnswersFormat),
-                  actions = Seq()
-                )
-              )
-          }
-
-          "when DispatchUseConsignorDetailsPage is true and there's no answer for ConsignorAddressPage" in new Test(
-            emptyUserAnswers
-              .set(DispatchUseConsignorDetailsPage, true)
-          ) {
-            DispatchAddressSummary.row() mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.addressLabel,
-                  value = ValueViewModel(messagesForLanguage.consignorSectionNotComplete),
-                  actions = Seq()
                 )
               )
           }

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchBusinessNameSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchBusinessNameSummarySpec.scala
@@ -44,7 +44,7 @@ class DispatchBusinessNameSummarySpec extends SpecBase with Matchers {
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
         "must output no row" - {
-          "when there's no answer for DispatchUseConsignorDetailsPage" in new Test(emptyUserAnswers) {
+          "when there's no answer for DispatchUseConsignorDetailsPage and there's no answer for DispatchBusinessNamePage" in new Test(emptyUserAnswers) {
             DispatchBusinessNameSummary.row() mustBe None
           }
 
@@ -71,6 +71,26 @@ class DispatchBusinessNameSummarySpec extends SpecBase with Matchers {
           "when DispatchUseConsignorDetailsPage is false and there's an answer" in new Test(
             emptyUserAnswers
               .set(DispatchUseConsignorDetailsPage, false)
+              .set(DispatchBusinessNamePage, "business name")
+          ) {
+            DispatchBusinessNameSummary.row() mustBe
+              Some(
+                SummaryListRowViewModel(
+                  key = messagesForLanguage.traderNameLabel,
+                  value = Value(Text("business name")),
+                  actions = Seq(
+                    ActionItemViewModel(
+                      content = messagesForLanguage.change,
+                      href = controllers.sections.dispatch.routes.DispatchBusinessNameController.onPageLoad(testErn, testDraftId, CheckMode).url,
+                      id = "changeDispatchBusinessName"
+                    ).withVisuallyHiddenText(messagesForLanguage.traderNameChangeHidden)
+                  )
+                )
+              )
+          }
+
+          "when DispatchUseConsignorDetailsPage is None and there's an answer" in new Test(
+            emptyUserAnswers
               .set(DispatchBusinessNamePage, "business name")
           ) {
             DispatchBusinessNameSummary.row() mustBe

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelperSpec.scala
@@ -18,19 +18,14 @@ package viewmodels.checkAnswers.sections.dispatch
 
 import base.SpecBase
 import fixtures.UserAddressFixtures
-import fixtures.messages.sections.dispatch.DispatchCheckAnswersMessages
 import models.UserAnswers
 import models.requests.DataRequest
-import pages.sections.dispatch.{DispatchAddressPage, DispatchBusinessNamePage, DispatchUseConsignorDetailsPage}
+import pages.sections.dispatch.{DispatchAddressPage, DispatchBusinessNamePage, DispatchUseConsignorDetailsPage, DispatchWarehouseExcisePage}
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import viewmodels.govuk.all.FluentSummaryList
-import viewmodels.govuk.summarylist._
-import viewmodels.implicits._
 
 class DispatchCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures {
 
@@ -43,9 +38,10 @@ class DispatchCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures {
 
   "CheckAnswersDispatchHelper" - {
 
-    ".buildSummaryRows should return the correct rows" - {
+    ".buildSummaryRows" - {
 
-      "when DispatchUseConsignorDetailsPage is false" in new Setup(emptyUserAnswers
+      "should return the correct rows" in new Setup(emptyUserAnswers
+        .set(DispatchWarehouseExcisePage, testErn)
         .set(DispatchBusinessNamePage, "Some Business Name")
         .set(DispatchUseConsignorDetailsPage, false)
         .set(DispatchAddressPage, userAddressModelMax)
@@ -56,33 +52,6 @@ class DispatchCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures {
           DispatchBusinessNameSummary.row()(fakeDataRequest, msgs),
           dispatchWarehouseExciseSummary.row()(fakeDataRequest, msgs),
           DispatchAddressSummary.row()(fakeDataRequest, msgs)
-        ).flatten).withCssClass("govuk-!-margin-bottom-9")
-
-
-        dispatchCheckAnswersSummary.summaryList() mustBe expectedResult
-      }
-
-      "when DispatchUseConsignorDetailsPage is true" in new Setup(emptyUserAnswers
-        .set(DispatchBusinessNamePage, "Some Business Name")
-        .set(DispatchUseConsignorDetailsPage, true)
-        .set(DispatchAddressPage, userAddressModelMax)
-      ) {
-
-        val expectedResult: SummaryList = SummaryList(Seq(
-          DispatchUseConsignorDetailsSummary.row()(fakeDataRequest, msgs),
-          Some(
-            SummaryListRowViewModel(
-              key = DispatchCheckAnswersMessages.English.traderNameLabel,
-              value = ValueViewModel(HtmlFormat.escape(testMinTraderKnownFacts.traderName).toString),
-              actions = Seq()
-            )
-          ),
-          dispatchWarehouseExciseSummary.row()(fakeDataRequest, msgs),
-          Some(SummaryListRowViewModel(
-            key = DispatchCheckAnswersMessages.English.addressLabel,
-            value = ValueViewModel(Text(DispatchCheckAnswersMessages.English.consignorSectionNotComplete)),
-            actions = Seq()
-          ))
         ).flatten).withCssClass("govuk-!-margin-bottom-9")
 
 

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelperSpec.scala
@@ -49,8 +49,8 @@ class DispatchCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures {
 
         val expectedResult: SummaryList = SummaryList(Seq(
           DispatchUseConsignorDetailsSummary.row()(fakeDataRequest, msgs),
-          DispatchBusinessNameSummary.row()(fakeDataRequest, msgs),
           dispatchWarehouseExciseSummary.row()(fakeDataRequest, msgs),
+          DispatchBusinessNameSummary.row()(fakeDataRequest, msgs),
           DispatchAddressSummary.row()(fakeDataRequest, msgs)
         ).flatten).withCssClass("govuk-!-margin-bottom-9")
 

--- a/test/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/dispatch/DispatchCheckAnswersHelperSpec.scala
@@ -50,8 +50,8 @@ class DispatchCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures {
         val expectedResult: SummaryList = SummaryList(Seq(
           DispatchUseConsignorDetailsSummary.row()(fakeDataRequest, msgs),
           dispatchWarehouseExciseSummary.row()(fakeDataRequest, msgs),
-          DispatchBusinessNameSummary.row()(fakeDataRequest, msgs),
-          DispatchAddressSummary.row()(fakeDataRequest, msgs)
+          Some(DispatchBusinessNameSummary.row()(fakeDataRequest, msgs)),
+          Some(DispatchAddressSummary.row()(fakeDataRequest, msgs))
         ).flatten).withCssClass("govuk-!-margin-bottom-9")
 
 


### PR DESCRIPTION
- IF consignor address has not been provided yet, then no longer ask "Do you want to use Consignor Details" question
- IF consignor address has been provided, and the user selected "Yes" to using them THEN
  - copies the Consignor Address to the Dispatch Address (pre-populating)
  - navigates them to the Dispatch Address page with the details pre-populated
- Dispatch Address now has additional validation to check that postcode starts BT for a NI Warehouse. Non-BT for a GB Warehouse.
- Updates made to model construction on submission and when playing back the CYA
- User can now change the address on the CYA even if they've said "Yes" to using the Consignor Details.
- Navigation updates to ensure correct pages are displayed based on whether ConsignorAddress exists or not
- Cleanse answers if value changes from XI --> GB or GB --> XI _(re-capture address)_