### PR TITLE
[ETFE-3731] - Restructure small producer page + update downstream data

### DIFF
--- a/app/controllers/DeclarationController.scala
+++ b/app/controllers/DeclarationController.scala
@@ -21,7 +21,7 @@ import controllers.actions._
 import handlers.ErrorHandler
 import models.NormalMode
 import models.requests.DataRequest
-import models.response.{MissingMandatoryPage, UnfixedSubmissionFailuresException}
+import models.response.MissingMandatoryPage
 import models.submitCreateMovement.SubmitCreateMovementModel
 import navigation.Navigator
 import pages.DeclarationPage
@@ -56,7 +56,7 @@ class DeclarationController @Inject()(
     authorisedDataRequestAsync(ern, draftId) { implicit request =>
       withSubmitCreateMovementModel { _ =>
         validationService.validate().map { validatedAnswers =>
-          if (AllSections.isCompleted(request.copy(userAnswers =  validatedAnswers))) {
+          if (AllSections.isCompleted(request.copy(userAnswers = validatedAnswers))) {
             Ok(view(submitAction = routes.DeclarationController.onSubmit(ern, draftId)))
           } else {
             logger.info("[onPageLoad] Validation Error was triggered, redirect to task list for User to correct")
@@ -86,9 +86,6 @@ class DeclarationController @Inject()(
     Try(SubmitCreateMovementModel.apply) match {
       case Failure(exception: MissingMandatoryPage) =>
         logger.warn(s"[withSubmitCreateMovementModel] MissingMandatoryPage error thrown: ${exception.message}")
-        Future.successful(Redirect(routes.DraftMovementController.onPageLoad(request.ern, request.draftId)))
-
-      case Failure(_: UnfixedSubmissionFailuresException) =>
         Future.successful(Redirect(routes.DraftMovementController.onPageLoad(request.ern, request.draftId)))
 
       case Failure(exception) =>

--- a/app/controllers/DeclarationController.scala
+++ b/app/controllers/DeclarationController.scala
@@ -21,7 +21,7 @@ import controllers.actions._
 import handlers.ErrorHandler
 import models.NormalMode
 import models.requests.DataRequest
-import models.response.MissingMandatoryPage
+import models.response.{MissingMandatoryPage, UnfixedSubmissionFailuresException}
 import models.submitCreateMovement.SubmitCreateMovementModel
 import navigation.Navigator
 import pages.DeclarationPage
@@ -88,9 +88,8 @@ class DeclarationController @Inject()(
         logger.warn(s"[withSubmitCreateMovementModel] MissingMandatoryPage error thrown: ${exception.message}")
         Future.successful(Redirect(routes.DraftMovementController.onPageLoad(request.ern, request.draftId)))
 
-      //TODO: add in when ETFE-3340 frontend has been merged (impossible to fix error as of: 13/03/24)
-      //      case Failure(_: UnfixedSubmissionFailuresException) =>
-      //        Future.successful(Redirect(routes.DraftMovementController.onPageLoad(request.ern, request.draftId)))
+      case Failure(_: UnfixedSubmissionFailuresException) =>
+        Future.successful(Redirect(routes.DraftMovementController.onPageLoad(request.ern, request.draftId)))
 
       case Failure(exception) =>
         logger.error(s"[withSubmitCreateMovementModel] Error thrown when creating request model to submit: ${exception.getMessage}")

--- a/app/controllers/sections/consignee/ConsigneeIndexController.scala
+++ b/app/controllers/sections/consignee/ConsigneeIndexController.scala
@@ -21,7 +21,7 @@ import controllers.actions._
 import models._
 import models.requests.UserRequest
 import models.sections.info.movementScenario.MovementScenario
-import models.sections.info.movementScenario.MovementScenario.{UkTaxWarehouse, _}
+import models.sections.info.movementScenario.MovementScenario._
 import navigation.ConsigneeNavigator
 import pages.sections.consignee.ConsigneeSection
 import pages.sections.info.DestinationTypePage

--- a/app/controllers/sections/items/ItemSmallIndependentProducerController.scala
+++ b/app/controllers/sections/items/ItemSmallIndependentProducerController.scala
@@ -69,11 +69,11 @@ class ItemSmallIndependentProducerController @Inject()(
     }
 
   private def renderView(status: Status, form: Form[_], idx: Index, mode: Mode)(implicit request: DataRequest[_]): Future[Result] =
-    withGoodsTypeAsync(idx) { goodsType =>
+    withGoodsTypeAsync(idx) { _ =>
       Future.successful(status(view(
         form = form,
         action = routes.ItemSmallIndependentProducerController.onSubmit(request.ern, request.draftId, idx, mode),
-        goodsType = goodsType
+        index = idx
       )))
     }
 

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -19,7 +19,7 @@ package forms.mappings
 import models.Enumerable
 import play.api.data.{FieldMapping, Mapping}
 import play.api.data.Forms.of
-import uk.gov.voa.play.form.{ConditionalMapping, MandatoryOptionalMapping}
+import uk.gov.voa.play.form.{Condition, ConditionalMapping, MandatoryOptionalMapping}
 
 import java.time.{LocalDate, LocalTime}
 
@@ -93,7 +93,7 @@ trait Mappings extends Formatters with Constraints {
    * @tparam T the data type that this field is
    * @return The mapping that should be applied based on the arguments and their values within the form
    */
-  def mandatoryIfOptionSelectedAndInputNonEmpty[T](optionField: String,
+  protected def mandatoryIfOptionSelectedAndInputNonEmpty[T](optionField: String,
                                                    optionValue: String,
                                                    inputField: String,
                                                    mapping: Mapping[T]
@@ -104,4 +104,7 @@ trait Mappings extends Formatters with Constraints {
       None,
       Seq.empty
     )
+
+  protected def isOptionSelected(field: String, option: String): Condition =
+    _.get(field).contains(option)
 }

--- a/app/forms/sections/items/ItemDesignationOfOriginFormProvider.scala
+++ b/app/forms/sections/items/ItemDesignationOfOriginFormProvider.scala
@@ -25,6 +25,7 @@ import play.api.data.Form
 import play.api.data.Forms.{mapping, text => playText}
 import uk.gov.voa.play.form.Condition
 import uk.gov.voa.play.form.ConditionalMappings.mandatoryIf
+import utils.ExciseProductCodeHelper.isSpirituousBeverages
 
 import javax.inject.Inject
 
@@ -67,7 +68,7 @@ class ItemDesignationOfOriginFormProvider @Inject() extends Mappings {
     )
 
   //Doesn't matter what is in the form (map needed for compatibility with conditional mapping lib)
-  private[items] def isS200(epc: String): Condition = _ => epc == "S200"
+  private[items] def isS200(epc: String): Condition = _ => isSpirituousBeverages(epc)
 
   private[items] def applyModel(geographicalIndication: ItemGeographicalIndicationType, pdoTextField: Option[String], pgiTextField: Option[String], isSpiritMarketedAndLabelled: Option[Boolean]) = {
     val geographicalIndicationIdentification = geographicalIndication match {

--- a/app/forms/sections/items/ItemSmallIndependentProducerFormProvider.scala
+++ b/app/forms/sections/items/ItemSmallIndependentProducerFormProvider.scala
@@ -16,15 +16,46 @@
 
 package forms.sections.items
 
-import javax.inject.Inject
-
+import forms.XSS_REGEX
 import forms.mappings.Mappings
+import forms.sections.items.ItemSmallIndependentProducerFormProvider._
+import models.sections.items.ItemSmallIndependentProducerType.SelfCertifiedIndependentSmallProducerAndNotConsignor
+import models.sections.items.{ItemSmallIndependentProducerModel, ItemSmallIndependentProducerType}
 import play.api.data.Form
+import play.api.data.Forms.mapping
+import uk.gov.voa.play.form.ConditionalMappings.mandatoryIf
+
+import javax.inject.Inject
 
 class ItemSmallIndependentProducerFormProvider @Inject() extends Mappings {
 
-  def apply(): Form[Boolean] =
+  def apply(): Form[ItemSmallIndependentProducerModel] =
     Form(
-      "value" -> boolean("itemSmallIndependentProducer.error.required")
+      mapping(
+        producerField -> enumerable[ItemSmallIndependentProducerType](producerRequiredError),
+        producerIdField -> mandatoryIf(isOptionSelected(producerField, SelfCertifiedIndependentSmallProducerAndNotConsignor.toString),
+          text(producerIdRequiredError)
+            .verifying(maxLength(producerIdMaxLength, producerIdMaxLengthError))
+            .verifying(regexpUnlessEmpty(XSS_REGEX, producerIdInvalidError))
+        )
+      )(ItemSmallIndependentProducerModel.apply)(ItemSmallIndependentProducerModel.unapply)
     )
+
+}
+
+object ItemSmallIndependentProducerFormProvider {
+
+  val producerField = "producer"
+
+  val producerIdField = "producerId"
+
+  val producerIdMaxLength = 16
+
+  val producerRequiredError = "itemSmallIndependentProducer.error.producer.required"
+
+  val producerIdRequiredError = "itemSmallIndependentProducer.error.producerId.required"
+
+  val producerIdMaxLengthError = "itemSmallIndependentProducer.error.producerId.length"
+
+  val producerIdInvalidError = "itemSmallIndependentProducer.error.producerId.invalid"
 }

--- a/app/models/response/ErrorResponse.scala
+++ b/app/models/response/ErrorResponse.scala
@@ -50,8 +50,6 @@ case class SubmitCreateMovementException(message: String) extends Exception(mess
 
 case class UserAnswersException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
 
-case class UnfixedSubmissionFailuresException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
-
 case class MissingMandatoryPage(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
 
 case class TraderKnownFactsException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse

--- a/app/models/sections/items/ItemSmallIndependentProducerModel.scala
+++ b/app/models/sections/items/ItemSmallIndependentProducerModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package pages.sections.items
+package models.sections.items
 
-import models.Index
-import models.sections.items.ItemSmallIndependentProducerModel
-import pages.QuestionPage
-import play.api.libs.json.JsPath
+import play.api.libs.json.{Format, Json}
 
-case class ItemSmallIndependentProducerPage(idx: Index) extends QuestionPage[ItemSmallIndependentProducerModel] {
-  override val toString: String = "itemSmallIndependentProducer"
-  override val path: JsPath = ItemsSectionItem(idx).path \ toString
+case class ItemSmallIndependentProducerModel(producerType: ItemSmallIndependentProducerType, producerId: Option[String])
+
+object ItemSmallIndependentProducerModel {
+
+  implicit val format: Format[ItemSmallIndependentProducerModel] = Json.format[ItemSmallIndependentProducerModel]
+
 }

--- a/app/models/sections/items/ItemSmallIndependentProducerType.scala
+++ b/app/models/sections/items/ItemSmallIndependentProducerType.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.sections.items
+
+import models.{Enumerable, WithName}
+
+sealed trait ItemSmallIndependentProducerType
+
+case object ItemSmallIndependentProducerType extends Enumerable.Implicits {
+
+  case object CertifiedIndependentSmallProducer extends WithName("CertifiedProducer") with ItemSmallIndependentProducerType
+
+  case object SelfCertifiedIndependentSmallProducerAndConsignor extends WithName("SelfCertifiedProducerAndConsignor") with ItemSmallIndependentProducerType
+
+  case object SelfCertifiedIndependentSmallProducerAndNotConsignor extends WithName("SelfCertifiedProducerAndNotConsignor") with ItemSmallIndependentProducerType
+
+  case object NotAIndependentSmallProducer extends WithName("None") with ItemSmallIndependentProducerType
+
+  case object NotProvided extends WithName("NotProvided") with ItemSmallIndependentProducerType
+
+  val values: Seq[ItemSmallIndependentProducerType] = Seq(
+    CertifiedIndependentSmallProducer,
+    SelfCertifiedIndependentSmallProducerAndConsignor,
+    SelfCertifiedIndependentSmallProducerAndNotConsignor,
+    NotAIndependentSmallProducer,
+    NotProvided
+  )
+
+  implicit val enumerable: Enumerable[ItemSmallIndependentProducerType] =
+    Enumerable(values.map(v => v.toString -> v): _*)
+}

--- a/app/models/submitCreateMovement/SubmitCreateMovementModel.scala
+++ b/app/models/submitCreateMovement/SubmitCreateMovementModel.scala
@@ -18,6 +18,7 @@ package models.submitCreateMovement
 
 import config.AppConfig
 import models.requests.DataRequest
+import models.response.UnfixedSubmissionFailuresException
 import models.sections.info.DispatchPlace
 import models.sections.info.movementScenario.{MovementScenario, MovementType}
 import models.{NorthernIrelandCertifiedConsignor, NorthernIrelandRegisteredConsignor, NorthernIrelandTemporaryCertifiedConsignor, NorthernIrelandWarehouseKeeper, UserType}
@@ -72,11 +73,10 @@ object SubmitCreateMovementModel extends ModelConstructorHelpers {
     val movementScenario: MovementScenario = mandatoryPage(DestinationTypePage)
 
     //Prevent user manually accessing the declaration page when unfixed submission failures exist
-    //TODO: add in when ETFE-3340 frontend has been merged (impossible to fix error as of: 13/03/24)
-    //if(!request.userAnswers.haveAllSubmissionErrorsBeenFixed) {
-    //  logger.warn("[SubmitCreateMovementModel][apply] - User attempted to submit movement but there are still unfixed submission failures")
-    //  throw UnfixedSubmissionFailuresException("Failed to create SubmitCreateMovementModel due to unfixed submission failures")
-    //}
+    if(!request.userAnswers.haveAllSubmissionErrorsBeenFixed) {
+      logger.warn("[SubmitCreateMovementModel][apply] - User attempted to submit movement but there are still unfixed submission failures")
+      throw UnfixedSubmissionFailuresException("Failed to create SubmitCreateMovementModel due to unfixed submission failures")
+    }
 
     SubmitCreateMovementModel(
       movementType = movementScenario.movementType,

--- a/app/models/submitCreateMovement/SubmitCreateMovementModel.scala
+++ b/app/models/submitCreateMovement/SubmitCreateMovementModel.scala
@@ -18,7 +18,6 @@ package models.submitCreateMovement
 
 import config.AppConfig
 import models.requests.DataRequest
-import models.response.UnfixedSubmissionFailuresException
 import models.sections.info.DispatchPlace
 import models.sections.info.movementScenario.{MovementScenario, MovementType}
 import models.{NorthernIrelandCertifiedConsignor, NorthernIrelandRegisteredConsignor, NorthernIrelandTemporaryCertifiedConsignor, NorthernIrelandWarehouseKeeper, UserType}
@@ -71,12 +70,6 @@ object SubmitCreateMovementModel extends ModelConstructorHelpers {
   def apply(implicit request: DataRequest[_], messages: Messages, appConfig: AppConfig): SubmitCreateMovementModel = {
 
     val movementScenario: MovementScenario = mandatoryPage(DestinationTypePage)
-
-    //Prevent user manually accessing the declaration page when unfixed submission failures exist
-    if(!request.userAnswers.haveAllSubmissionErrorsBeenFixed) {
-      logger.warn("[SubmitCreateMovementModel][apply] - User attempted to submit movement but there are still unfixed submission failures")
-      throw UnfixedSubmissionFailuresException("Failed to create SubmitCreateMovementModel due to unfixed submission failures")
-    }
 
     SubmitCreateMovementModel(
       movementType = movementScenario.movementType,

--- a/app/navigation/ItemsNavigator.scala
+++ b/app/navigation/ItemsNavigator.scala
@@ -26,7 +26,8 @@ import pages.Page
 import pages.sections.items._
 import play.api.mvc.Call
 import queries.{ItemsCount, ItemsPackagingCount}
-import utils.{CommodityCodeHelper, ExciseProductCodeHelper}
+import utils.CommodityCodeHelper
+import utils.ExciseProductCodeHelper.{isSpiritAndNotSpirituousBeverages, isSpirituousBeverages}
 
 import javax.inject.Inject
 
@@ -391,10 +392,15 @@ class ItemsNavigator @Inject() extends BaseNavigator {
               itemsRoutes.ItemQuantityController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
             }
 
-          case Spirits if Seq("S300", "S400", "S500", "S600").contains(epc) && abv < 8.5 =>
+          case Spirits if isSpirituousBeverages(epc) =>
+            itemsRoutes.ItemMaturationPeriodAgeController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
+
+          case Spirits if isSpiritAndNotSpirituousBeverages(epc) && abv < 8.5 =>
             itemsRoutes.ItemSmallIndependentProducerController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
 
-          case Spirits => itemsRoutes.ItemMaturationPeriodAgeController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
+          case Spirits if isSpiritAndNotSpirituousBeverages(epc) && abv >= 8.5 =>
+            itemsRoutes.ItemQuantityController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
+
           case _ =>
             itemsRoutes.ItemDesignationOfOriginController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
         }

--- a/app/navigation/ItemsNavigator.scala
+++ b/app/navigation/ItemsNavigator.scala
@@ -19,6 +19,7 @@ package navigation
 import controllers.sections.items.{routes => itemsRoutes}
 import models.GoodsType._
 import models._
+import models.sections.items.ItemSmallIndependentProducerType.{SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.sections.items.ItemWineProductCategory.ImportedWine
 import models.sections.items.{ItemsAddToList, ItemsPackagingAddToList}
 import pages.Page
@@ -82,8 +83,8 @@ class ItemsNavigator @Inject() extends BaseNavigator {
       }
 
     case ItemSmallIndependentProducerPage(idx) => (userAnswers: UserAnswers) =>
-      userAnswers.get(ItemSmallIndependentProducerPage(idx)) match {
-        case Some(true) =>
+      userAnswers.get(ItemSmallIndependentProducerPage(idx)).map(_.producerType) match {
+        case Some(SelfCertifiedIndependentSmallProducerAndConsignor | SelfCertifiedIndependentSmallProducerAndNotConsignor) =>
           itemsRoutes.ItemProducerSizeController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
         case _ =>
           itemsRoutes.ItemQuantityController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
@@ -247,10 +248,11 @@ class ItemsNavigator @Inject() extends BaseNavigator {
       itemsRoutes.ItemCheckAnswersController.onPageLoad(answers.ern, answers.draftId, idx)
 
     case page@ItemSmallIndependentProducerPage(idx) => (answers: UserAnswers) =>
-      if (answers.get(page).contains(true)) {
-        itemsRoutes.ItemProducerSizeController.onPageLoad(answers.ern, answers.draftId, idx, CheckMode)
-      } else {
-        itemsRoutes.ItemCheckAnswersController.onPageLoad(answers.ern, answers.draftId, idx)
+      answers.get(page).map(_.producerType) match {
+        case Some(SelfCertifiedIndependentSmallProducerAndConsignor | SelfCertifiedIndependentSmallProducerAndNotConsignor) =>
+          itemsRoutes.ItemProducerSizeController.onPageLoad(answers.ern, answers.draftId, idx, CheckMode)
+        case _ =>
+          itemsRoutes.ItemCheckAnswersController.onPageLoad(answers.ern, answers.draftId, idx)
       }
 
     case ItemProducerSizePage(idx) => (answers: UserAnswers) =>
@@ -375,6 +377,7 @@ class ItemsNavigator @Inject() extends BaseNavigator {
   }
 
 
+  //scalastyle:off
   private def alcoholStrengthRouting(idx: Index, userAnswers: UserAnswers): Call =
     (userAnswers.get(ItemExciseProductCodePage(idx)), userAnswers.get(ItemAlcoholStrengthPage(idx))) match {
       case (Some(epc), Some(abv)) =>
@@ -387,12 +390,11 @@ class ItemsNavigator @Inject() extends BaseNavigator {
             } else {
               itemsRoutes.ItemQuantityController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
             }
-          case Spirits =>
-            if (ExciseProductCodeHelper.isSpirituousBeverages(epc)) {
-              itemsRoutes.ItemMaturationPeriodAgeController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
-            } else {
-              itemsRoutes.ItemDesignationOfOriginController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
-            }
+
+          case Spirits if Seq("S300", "S400", "S500", "S600").contains(epc) && abv < 8.5 =>
+            itemsRoutes.ItemSmallIndependentProducerController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
+
+          case Spirits => itemsRoutes.ItemMaturationPeriodAgeController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
           case _ =>
             itemsRoutes.ItemDesignationOfOriginController.onPageLoad(userAnswers.ern, userAnswers.draftId, idx, NormalMode)
         }

--- a/app/pages/sections/items/ItemsSectionItem.scala
+++ b/app/pages/sections/items/ItemsSectionItem.scala
@@ -18,6 +18,8 @@ package pages.sections.items
 
 import models.GoodsType._
 import models.requests.DataRequest
+import models.sections.items.ItemSmallIndependentProducerModel
+import models.sections.items.ItemSmallIndependentProducerType.{SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.sections.items.ItemWineProductCategory.ImportedWine
 import models.{GoodsType, Index}
 import pages.sections.Section
@@ -134,7 +136,9 @@ case class ItemsSectionItem(idx: Index) extends Section[JsObject] with JsonOptio
   private[items] def independentProducerAnswers(implicit goodsType: GoodsType, request: DataRequest[_]): Seq[Option[_]] =
     mandatoryIf(goodsType.isAlcohol && request.userAnswers.get(ItemAlcoholStrengthPage(idx)).exists(_ < 8.5)) {
       request.userAnswers.get(ItemSmallIndependentProducerPage(idx)) match {
-        case smallProducer@Some(true) => Seq(smallProducer, request.userAnswers.get(ItemProducerSizePage(idx)))
+        case smallProducer@Some(ItemSmallIndependentProducerModel(producerType, _))
+          if producerType == SelfCertifiedIndependentSmallProducerAndConsignor | producerType == SelfCertifiedIndependentSmallProducerAndNotConsignor =>
+          Seq(smallProducer, request.userAnswers.get(ItemProducerSizePage(idx)))
         case smallProducer => Seq(smallProducer)
       }
     }

--- a/app/pages/sections/items/ItemsSectionItem.scala
+++ b/app/pages/sections/items/ItemsSectionItem.scala
@@ -53,7 +53,7 @@ case class ItemsSectionItem(idx: Index) extends Section[JsObject] with JsonOptio
       maturationAgeAnswer(epc) ++
       wineCountryOfOriginAnswers ++
       wineMoreInformationAnswers ++
-      designationOfOriginAnswers ++
+      designationOfOriginAnswers(epc) ++
       alcoholStrengthAnswer ++
       itemDensityAnswer(epc) ++
       fiscalMarksAnswers
@@ -120,8 +120,8 @@ case class ItemsSectionItem(idx: Index) extends Section[JsObject] with JsonOptio
       }
     }
 
-  private[items] def designationOfOriginAnswers(implicit goodsType: GoodsType, request: DataRequest[_]): Seq[Option[_]] =
-    mandatoryIf(goodsType.isAlcohol && goodsType != Beer) {
+  private[items] def designationOfOriginAnswers(epc: String)(implicit goodsType: GoodsType, request: DataRequest[_]): Seq[Option[_]] =
+    mandatoryIf(goodsType.isAlcohol && (goodsType == Wine || goodsType == Intermediate || ExciseProductCodeHelper.isSpirituousBeverages(epc))) {
       //Whilst Statement of spirit marketing and labelling is required for S200 EPC's, the page (or specifically, the form) should
       //prevent the user from continuing if they hadn't selected an option
       Seq(request.userAnswers.get(ItemDesignationOfOriginPage(idx)))

--- a/app/utils/ExciseProductCodeHelper.scala
+++ b/app/utils/ExciseProductCodeHelper.scala
@@ -19,4 +19,6 @@ package utils
 object ExciseProductCodeHelper {
 
   def isSpirituousBeverages(epc: String): Boolean = epc == "S200"
+
+  def isSpiritAndNotSpirituousBeverages(epc: String): Boolean = Seq("S300", "S400", "S500", "S600").contains(epc)
 }

--- a/app/viewmodels/checkAnswers/sections/items/ItemProducerSizeSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/items/ItemProducerSizeSummary.scala
@@ -18,6 +18,7 @@ package viewmodels.checkAnswers.sections.items
 
 import controllers.sections.items.routes
 import models.requests.DataRequest
+import models.sections.items.ItemSmallIndependentProducerType.{SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.{CheckMode, Index}
 import pages.sections.items.{ItemProducerSizePage, ItemSmallIndependentProducerPage}
 import play.api.i18n.Messages
@@ -34,7 +35,7 @@ object ItemProducerSizeSummary {
     for {
       itemSmallIndependentProducer <- request.userAnswers.get(ItemSmallIndependentProducerPage(idx))
       answer <- request.userAnswers.get(page)
-      if itemSmallIndependentProducer
+      if itemSmallIndependentProducer.producerType == SelfCertifiedIndependentSmallProducerAndConsignor || itemSmallIndependentProducer.producerType == SelfCertifiedIndependentSmallProducerAndNotConsignor
     } yield {
       SummaryListRowViewModel(
         key = s"$page.checkYourAnswersLabel",

--- a/app/viewmodels/checkAnswers/sections/items/ItemSmallIndependentProducerSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/items/ItemSmallIndependentProducerSummary.scala
@@ -21,21 +21,38 @@ import models.requests.DataRequest
 import models.{CheckMode, Index}
 import pages.sections.items.ItemSmallIndependentProducerPage
 import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.Aliases.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
+import viewmodels.helpers.ItemSmallIndependentProducerHelper
 import viewmodels.implicits._
+import views.html.components.p
 
-object ItemSmallIndependentProducerSummary {
+import javax.inject.Inject
+
+class ItemSmallIndependentProducerSummary @Inject()(p: p) {
 
   def row(idx: Index)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
     lazy val page = ItemSmallIndependentProducerPage(idx)
 
     request.userAnswers.get(page).map {
-      answer =>
-        val value = if (answer) "site.yes" else "site.no"
+      answerModel =>
+
+        val declaration = ItemSmallIndependentProducerHelper.constructDeclarationPrefix(idx).dropRight(1)
+
+        val answer = messages(s"itemSmallIndependentProducer.${answerModel.producerType}")
+
+        val optSeedNumber = answerModel.producerId.map(messages("itemSmallIndependentProducer.cya.seedNumber", _))
+
+        val content = Seq(
+          Some(p()(Text(declaration).asHtml)),
+          Some(p()(Text(answer).asHtml)),
+          optSeedNumber.map(seedNumber => p()(Text(seedNumber).asHtml))
+        ).flatten.mkString
+
         SummaryListRowViewModel(
           key = s"$page.checkYourAnswersLabel",
-          value = ValueViewModel(messages(value)),
+          value = ValueViewModel(HtmlContent(content)),
           actions = Seq(ActionItemViewModel(
             href = routes.ItemSmallIndependentProducerController.onPageLoad(request.ern, request.draftId, idx, CheckMode).url,
             content = "site.change",

--- a/app/viewmodels/helpers/ItemCheckAnswersHelper.scala
+++ b/app/viewmodels/helpers/ItemCheckAnswersHelper.scala
@@ -39,7 +39,8 @@ class ItemCheckAnswersHelper @Inject()(
                                         itemBulkPackagingSealTypeSummary: ItemBulkPackagingSealTypeSummary,
                                         itemQuantitySummary: ItemQuantitySummary,
                                         itemDegreesPlatoSummary: ItemDegreesPlatoSummary,
-                                        itemDesignationOfOriginSummary: ItemDesignationOfOriginSummary
+                                        itemDesignationOfOriginSummary: ItemDesignationOfOriginSummary,
+                                        itemSmallIndependentProducerSummary: ItemSmallIndependentProducerSummary
                                       ) {
 
   private val headingLevel = 3
@@ -60,7 +61,7 @@ class ItemCheckAnswersHelper @Inject()(
         ItemFiscalMarksChoiceSummary.row(idx),
         ItemFiscalMarksSummary.row(idx),
         itemDesignationOfOriginSummary.row(idx),
-        ItemSmallIndependentProducerSummary.row(idx),
+        itemSmallIndependentProducerSummary.row(idx),
         ItemProducerSizeSummary.row(idx)
       ).flatten
     )

--- a/app/viewmodels/helpers/ItemSmallIndependentProducerHelper.scala
+++ b/app/viewmodels/helpers/ItemSmallIndependentProducerHelper.scala
@@ -96,7 +96,7 @@ object ItemSmallIndependentProducerHelper {
       request.userAnswers.get(ItemExciseProductCodePage(itemIndex)),
       request.userAnswers.get(ItemCommodityCodePage(itemIndex))
     ) match {
-      case (Some(GbTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu), _, _) =>
+      case (Some(UkTaxWarehouse.GB | UkTaxWarehouse.NI | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu), _, _) =>
         messages("itemSmallIndependentProducer.certifiedStatement.smallProducer")
       case (Some(movementScenario), Some(epc), Some(cnCode)) if isNiToEUMovement(movementScenario) =>
         handleNiToEuMovementDeclaration(epc, cnCode)

--- a/app/views/sections/items/ItemSmallIndependentProducerView.scala.html
+++ b/app/views/sections/items/ItemSmallIndependentProducerView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import forms.sections.items.ItemSmallIndependentProducerFormProvider.producerField
 @import models.GoodsType
 @import models.requests.DataRequest
+@import models.sections.items.ItemSmallIndependentProducerType.CertifiedIndependentSmallProducer
 @import viewmodels.helpers.ItemSmallIndependentProducerHelper
 
 @this(
@@ -23,26 +25,30 @@
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukRadios: GovukRadios,
+        helper: ItemSmallIndependentProducerHelper,
         continueOrExit: components.continueOrExit,
         h1: components.h1,
-        h2: components.h2
+        h2: components.h2,
+        p: components.p
 )
 
-@(form: Form[_], action: Call, goodsType: GoodsType)(implicit request: DataRequest[_], messages: Messages)
+@(form: Form[_], action: Call, index: Index)(implicit request: DataRequest[_], messages: Messages)
 
-@layout(pageTitle = title(form, messages("itemSmallIndependentProducer.title", goodsType.toSingularOutput())), maybeShowActiveTrader = maybeShowActiveTrader(request)) {
+@layout(pageTitle = title(form, messages("itemSmallIndependentProducer.title")), maybeShowActiveTrader = maybeShowActiveTrader(request)) {
 
     @formHelper(action, 'autoComplete -> "off") {
 
         @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form))
+            @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map(producerField -> form(s"$producerField-$CertifiedIndependentSmallProducer").id)))
         }
 
         @h2(messages("items.subHeading", request.draftId), "govuk-caption-xl", hiddenContent = Some(messages("subHeading.hidden")))
 
-        @govukRadios(
-            ItemSmallIndependentProducerHelper.radios(form, goodsType)
-        )
+        @h1(messages("itemSmallIndependentProducer.heading"), classes = "govuk-heading-l")
+
+        @p() { @ItemSmallIndependentProducerHelper.constructDeclarationPrefix(index) }
+
+        @govukRadios(helper.radios(form))
 
         @continueOrExit()
     }

--- a/conf/messages
+++ b/conf/messages
@@ -1143,19 +1143,33 @@ itemDegreesPlato.amount.error.nonNumeric = Amount must only include numbers
 itemDegreesPlato.amount.error.range = Enter an amount with up to 2 decimal places between {0} and {1}
 itemDegreesPlato.amount.error.decimalPlaces = Amount can have up to 2 decimal places
 
-itemSmallIndependentProducer.title = Can you confirm that the producer of the {0} is certified as an independent small producer?
-itemSmallIndependentProducer.heading = Can you confirm that the producer of the {0} is certified as an independent small producer?
-itemSmallIndependentProducer.p1 = Certification and details of eligibility should be provided by those intending to claim Small Producer Relief on alcohol.
-itemSmallIndependentProducer.yes = Yes - {0}
-itemSmallIndependentProducer.yes.beer = It is hereby certified that the product described has been produced by an independent small brewery
-itemSmallIndependentProducer.yes.wine = It is hereby certified that the product described has been produced by an independent small wine producer
-itemSmallIndependentProducer.yes.fermented = It is hereby certified that the product described has been produced by an independent small producer of fermented beverages other than wine and beer
-itemSmallIndependentProducer.yes.intermediate = It is hereby certified that the product described has been produced by an independent small intermediate products producer
-itemSmallIndependentProducer.yes.spirits = It is hereby certified that the product described has been produced by an independent small distillery
-itemSmallIndependentProducer.yes.other = It is hereby certified that the alcoholic product described has been produced by an independent small producer
-itemSmallIndependentProducer.error.required = Select ‘Yes’ if the product has been produced by a certified independent small producer
-itemSmallIndependentProducer.checkYourAnswersLabel = Independent small producer
-itemSmallIndependentProducer.change.hidden = if the producer is an independent small producer
+itemSmallIndependentProducer.title = Independent small producer declaration
+itemSmallIndependentProducer.heading = Independent small producer declaration
+itemSmallIndependentProducer.legend = Who is the independent small producer?
+
+itemSmallIndependentProducer.certifiedStatement.smallProducer = It is hereby certified that the alcoholic product described has been produced by an independent small producer.
+itemSmallIndependentProducer.certifiedStatement.smallBrewery = It is hereby certified that the alcoholic product described has been produced by an independent small brewery.
+itemSmallIndependentProducer.certifiedStatement.smallDistillery = It is hereby certified that the alcoholic product described has been produced by an independent small distillery.
+itemSmallIndependentProducer.certifiedStatement.wineProducer = It is hereby certified that the alcoholic product described has been produced by an independent wine producer.
+itemSmallIndependentProducer.certifiedStatement.fermentedBeveragesProducer = It is hereby certified that the alcoholic product described has been produced by an independent producer of fermented beverages other than wine and beer.
+itemSmallIndependentProducer.certifiedStatement.intermediateBeveragesProducer = It is hereby certified that the alcoholic product described has been produced by an independent intermediate products producer.
+
+itemSmallIndependentProducer.CertifiedProducer = The producer is a certified independent small producer
+itemSmallIndependentProducer.CertifiedProducer.hint = The certificate should be recorded in the Documents section of the eAD.
+itemSmallIndependentProducer.SelfCertifiedProducerAndConsignor = The producer is a self-certified independent small producer and the consignor
+itemSmallIndependentProducer.SelfCertifiedProducerAndNotConsignor = The producer is a self-certified independent small producer and not the consignor
+itemSmallIndependentProducer.SelfCertifiedProducerAndNotConsignor.input = Enter the self-certified producer’s excise ID or, if not available, the VAT registration number
+itemSmallIndependentProducer.None = The producer is not an independent small producer
+itemSmallIndependentProducer.NotProvided = I don’t want to provide information about the producer
+# Separation needed due to the service sending ’ as ..., the message key below maintains the apostrophe
+itemSmallIndependentProducer.NotProvided.downstream = I don''t want to provide information about the producer
+itemSmallIndependentProducer.error.producer.required = Select the type of producer or select ‘I don’t want to provide information about the producer’
+itemSmallIndependentProducer.error.producerId.required = You must provide an excise ID or, if not available, the VAT registration number
+itemSmallIndependentProducer.error.producerId.length = The excise ID or VAT registration number should be 16 characters or less
+itemSmallIndependentProducer.error.producerId.invalid = The excise ID or VAT registration number should only contain letters and numbers
+itemSmallIndependentProducer.cya.seedNumber = Seed number: {0}
+itemSmallIndependentProducer.checkYourAnswersLabel = Independent small producer declaration
+itemSmallIndependentProducer.change.hidden = Independent small producer declaration
 
 itemFiscalMarksChoice.title = Does the {0} have any fiscal marks?
 itemFiscalMarksChoice.heading = Does the {0} have any fiscal marks?

--- a/test-utils/fixtures/ItemFixtures.scala
+++ b/test-utils/fixtures/ItemFixtures.scala
@@ -25,6 +25,7 @@ import models.sections.info._
 import models.sections.info.movementScenario.{DestinationType, MovementScenario, MovementType, OriginType}
 import models.sections.items.ItemBulkPackagingCode._
 import models.sections.items.ItemGeographicalIndicationType.{NoGeographicalIndication, ProtectedDesignationOfOrigin}
+import models.sections.items.ItemSmallIndependentProducerType.SelfCertifiedIndependentSmallProducerAndNotConsignor
 import models.sections.items.ItemWineProductCategory.{ImportedWine, Other}
 import models.sections.items._
 import models.sections.journeyType.HowMovementTransported
@@ -270,6 +271,13 @@ trait ItemFixtures {
       "S",
       "Ethyl alcohol and spirits"
     )
+  val testExciseProductCodeS300: ExciseProductCode =
+    ExciseProductCode(
+      "S300",
+      "Ethyl alcohol",
+      "S",
+      "Ethyl alcohol and spirits"
+    )
   val testExciseProductCodeS400: ExciseProductCode =
     ExciseProductCode(
       "S400",
@@ -281,6 +289,13 @@ trait ItemFixtures {
     ExciseProductCode(
       "S500",
       "Other products containing ethyl alcohol",
+      "S",
+      "Ethyl alcohol and spirits"
+    )
+  val testExciseProductCodeS600: ExciseProductCode =
+    ExciseProductCode(
+      "S600",
+      "Completely denatured alcohol, falling within Article 20 of Directive 92/83/EEC, being alcohol which has been denatured and fulfils the conditions to benefit from the exemption provided for in Article 27(1)(a) of that Directive",
       "S",
       "Ethyl alcohol and spirits"
     )
@@ -435,7 +450,7 @@ trait ItemFixtures {
     .set(ItemFiscalMarksPage(testIndex1), "fiscal marks")
     .set(ItemFiscalMarksChoicePage(testIndex1), true)
     .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(ProtectedDesignationOfOrigin, Some("talkin' 'bout my deeeeeesignation"), None))
-    .set(ItemSmallIndependentProducerPage(testIndex1), true)
+    .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
     .set(ItemProducerSizePage(testIndex1), BigInt(4))
     .set(ItemDensityPage(testIndex1), BigDecimal(7.89))
     .set(ItemCommercialDescriptionPage(testIndex1), "beans")
@@ -546,7 +561,7 @@ trait ItemFixtures {
       fiscalMark = Some("fiscal marks"),
       fiscalMarkUsedFlag = Some(true),
       designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-      independentSmallProducersDeclaration = Some("It is hereby certified that the product described has been produced by an independent small wine producer"),
+      independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent wine producer. The producer is a self-certified independent small producer and not the consignor. Seed number: XIRC123456789"),
       sizeOfProducer = Some(BigInt(4)),
       density = Some(BigDecimal(7.89)),
       commercialDescription = Some("beans"),
@@ -679,7 +694,7 @@ trait ItemFixtures {
       fiscalMark = Some("fiscal marks"),
       fiscalMarkUsedFlag = Some(true),
       designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-      independentSmallProducersDeclaration = Some("It is hereby certified that the product described has been produced by an independent small wine producer"),
+      independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent wine producer. The producer is a self-certified independent small producer and not the consignor. Seed number: XIRC123456789"),
       sizeOfProducer = Some(BigInt(4)),
       density = Some(BigDecimal(7.89)),
       commercialDescription = Some("beans"),
@@ -725,7 +740,7 @@ trait ItemFixtures {
   )
 
   val gbrcSubmitCreateMovementModel: SubmitCreateMovementModel = SubmitCreateMovementModel(
-    movementType = MovementType.ImportEu,
+    movementType = MovementType.ImportUk,
     attributes = AttributesModel(SubmissionMessageType.Standard, Some(false)),
     consigneeTrader = Some(TraderModel(
       traderExciseNumber = Some("consignee ern"),
@@ -745,7 +760,7 @@ trait ItemFixtures {
     dispatchImportOffice = Some(OfficeModel("dispatch import office")),
     complementConsigneeTrader = Some(ComplementConsigneeTraderModel("state", Some("number"))),
     deliveryPlaceTrader = Some(TraderModel(
-      traderExciseNumber = None,
+      traderExciseNumber = Some(testErn),
       traderName = Some("destination name"),
       address = Some(AddressModel.fromUserAddress(testUserAddress.copy(street = "destination street"))),
       vatNumber = None,
@@ -776,7 +791,7 @@ trait ItemFixtures {
       )
     )),
     headerEadEsad = HeaderEadEsadModel(
-      destinationType = DestinationType.DirectDelivery,
+      destinationType = DestinationType.TaxWarehouse,
       journeyTime = "2 hours",
       transportArrangement = TransportArranger.GoodsOwner
     ),
@@ -806,7 +821,7 @@ trait ItemFixtures {
       fiscalMark = Some("fiscal marks"),
       fiscalMarkUsedFlag = Some(true),
       designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-      independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent small producer"),
+      independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent small producer. The producer is a self-certified independent small producer and not the consignor. Seed number: XIRC123456789"),
       sizeOfProducer = Some(BigInt(4)),
       density = Some(BigDecimal(7.89)),
       commercialDescription = Some("beans"),
@@ -852,7 +867,7 @@ trait ItemFixtures {
   )
 
   val gbwkSubmitCreateMovementModel: SubmitCreateMovementModel = SubmitCreateMovementModel(
-    movementType = MovementType.UkToEu,
+    movementType = MovementType.UkToUk,
     attributes = AttributesModel(SubmissionMessageType.Standard, Some(false)),
     consigneeTrader = Some(TraderModel(
       traderExciseNumber = Some("consignee ern"),
@@ -878,7 +893,7 @@ trait ItemFixtures {
     dispatchImportOffice = Some(OfficeModel("dispatch import office")),
     complementConsigneeTrader = Some(ComplementConsigneeTraderModel("state", Some("number"))),
     deliveryPlaceTrader = Some(TraderModel(
-      traderExciseNumber = None,
+      traderExciseNumber = Some(testErn),
       traderName = Some("destination name"),
       address = Some(AddressModel.fromUserAddress(testUserAddress.copy(street = "destination street"))),
       vatNumber = None,
@@ -909,7 +924,7 @@ trait ItemFixtures {
       )
     )),
     headerEadEsad = HeaderEadEsadModel(
-      destinationType = DestinationType.DirectDelivery,
+      destinationType = DestinationType.TaxWarehouse,
       journeyTime = "2 hours",
       transportArrangement = TransportArranger.GoodsOwner
     ),
@@ -939,7 +954,7 @@ trait ItemFixtures {
       fiscalMark = Some("fiscal marks"),
       fiscalMarkUsedFlag = Some(true),
       designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-      independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent small producer"),
+      independentSmallProducersDeclaration = Some(s"It is hereby certified that the alcoholic product described has been produced by an independent small producer. The producer is a self-certified independent small producer and not the consignor. Seed number: $testErn"),
       sizeOfProducer = Some(BigInt(4)),
       density = Some(BigDecimal(7.89)),
       commercialDescription = Some("beans"),

--- a/test-utils/fixtures/messages/BaseMessages.scala
+++ b/test-utils/fixtures/messages/BaseMessages.scala
@@ -65,6 +65,7 @@ trait BaseMessages { _: i18n =>
   val notificationBannerParagraph = "Some information needs updating"
   val notificationBannerParagraphForItems = "Some information needs updating"
   val warning: String = "Warning:"
+  val or = "or"
 }
 
 trait BaseEnglish extends BaseMessages with EN

--- a/test-utils/fixtures/messages/sections/consignee/ConsigneeExportInformationMessages.scala
+++ b/test-utils/fixtures/messages/sections/consignee/ConsigneeExportInformationMessages.scala
@@ -26,7 +26,6 @@ object ConsigneeExportInformationMessages {
 
     val checkboxItemForVat = "VAT registration number"
     val checkboxItemForEori = "EORI number"
-    val checkBoxItemDivider = "or"
     val checkboxItemForNoInfo = "I don't have any information about this person"
 
     val cyaLabel: String = "Identification provided"

--- a/test-utils/fixtures/messages/sections/items/ItemDesignationOfOriginMessages.scala
+++ b/test-utils/fixtures/messages/sections/items/ItemDesignationOfOriginMessages.scala
@@ -36,7 +36,6 @@ object ItemDesignationOfOriginMessages {
     val pdoInput = "Enter the name and register number of the PDO (optional)"
     val pgiRadio = "The product has a Protected Geographical Indication (PGI)"
     val pgiInput = "Enter the name and register number of the PGI (optional)"
-    val or = "or"
     val noGiRadio = "I don’t want to provide a statement about the designation of origin"
 
     val s200YesRadio = "It is hereby certified that the product described is marketed and labelled in compliance with Regulation (EU) 2019/787"

--- a/test-utils/fixtures/messages/sections/items/ItemSmallIndependentProducerMessages.scala
+++ b/test-utils/fixtures/messages/sections/items/ItemSmallIndependentProducerMessages.scala
@@ -21,19 +21,30 @@ import fixtures.messages.{BaseEnglish, BaseMessages, i18n}
 object ItemSmallIndependentProducerMessages {
 
   sealed trait ViewMessages extends BaseMessages { _: i18n =>
-    def heading(goodsType: String) = s"Can you confirm that the producer of the $goodsType is certified as an independent small producer?"
-    def title(goodsType: String): String = titleHelper(heading(goodsType))
+    val heading = "Independent small producer declaration"
+    val title: String = titleHelper(heading)
 
-    def yesCertified(value: String) = s"Yes - $value"
-    val yesBeer = "It is hereby certified that the product described has been produced by an independent small brewery"
-    val yesWine = "It is hereby certified that the product described has been produced by an independent small wine producer"
-    val yesFermented = "It is hereby certified that the product described has been produced by an independent small producer of fermented beverages other than wine and beer"
-    val yesIntermediate = "It is hereby certified that the product described has been produced by an independent small intermediate products producer"
-    val yesSpirits = "It is hereby certified that the product described has been produced by an independent small distillery"
-    val yesOther = "It is hereby certified that the alcoholic product described has been produced by an independent small producer"
+    val producedByIndependentSmallProducer = "It is hereby certified that the alcoholic product described has been produced by an independent small producer."
+    val producedByIndependentSmallBrewery = "It is hereby certified that the alcoholic product described has been produced by an independent small brewery."
+    val producedByIndependentSmallDistillery = "It is hereby certified that the alcoholic product described has been produced by an independent small distillery."
+    val producedByIndependentWineProducer = "It is hereby certified that the alcoholic product described has been produced by an independent wine producer."
+    val producedByIndependentFermentedBeveragesProducer = "It is hereby certified that the alcoholic product described has been produced by an independent producer of fermented beverages other than wine and beer."
+    val producedByIndependentIntermediateProductsProducer = "It is hereby certified that the alcoholic product described has been produced by an independent intermediate products producer."
 
-    val cyaLabel = "Independent small producer"
-    val cyaChangeHidden = "if the producer is an independent small producer"
+    val legend = "Who is the independent small producer?"
+
+    val certifiedIndependentSmallProducer = "The producer is a certified independent small producer"
+    val certifiedIndependentSmallProducerHint = "The certificate should be recorded in the Documents section of the eAD."
+    val selfCertifiedIndependentSmallProducerAndConsignor = "The producer is a self-certified independent small producer and the consignor"
+    val selfCertifiedIndependentSmallProducerNotConsignor = "The producer is a self-certified independent small producer and not the consignor"
+    val selfCertifiedIndependentSmallProducerNotConsignorInput = "Enter the self-certified producer’s excise ID or, if not available, the VAT registration number"
+    val notAIndependentSmallProducer = "The producer is not an independent small producer"
+    val smallProducerNotProvided = "I don’t want to provide information about the producer"
+
+    def seedNumber(value: String) = s"Seed number: $value"
+
+    val cyaLabel = "Independent small producer declaration"
+    val cyaChangeHidden = "Independent small producer declaration"
   }
 
   object English extends ViewMessages with BaseEnglish

--- a/test-utils/fixtures/messages/sections/items/ItemWineOperationsChoiceMessages.scala
+++ b/test-utils/fixtures/messages/sections/items/ItemWineOperationsChoiceMessages.scala
@@ -39,7 +39,6 @@ object ItemWineOperationsChoiceMessages {
     val checkBoxItem9 = "The product has been made on the basis of experimental use of a new oenological practice"
     val checkBoxItem10 = "The product has been partially dealcoholised"
     val checkBoxItem11 = "Other operations"
-    val checkBoxItem12 = "or"
     val checkBoxItem13 = "No, I am not aware that the wine has undergone any operations"
 
     val cyaLabel = "Wine operations"

--- a/test-utils/fixtures/messages/sections/transportUnit/TransportUnitAddToListMessages.scala
+++ b/test-utils/fixtures/messages/sections/transportUnit/TransportUnitAddToListMessages.scala
@@ -31,7 +31,6 @@ object TransportUnitAddToListMessages {
     val yesOption = "Yes"
     val noOptionSingular = "No, this is the only transport unit for this movement"
     val noOptionPlural = "No, these are all the transport units"
-    val optionDivider = "or"
     val laterOption = "I will add more transport units later"
     val errorMessage = "Select yes if you need to add another transport unit"
     val errorMessageHelper: String => String = s"Error: " + _

--- a/test/controllers/DeclarationControllerSpec.scala
+++ b/test/controllers/DeclarationControllerSpec.scala
@@ -99,7 +99,7 @@ class DeclarationControllerSpec extends SpecBase
         redirectLocation(res).value mustBe routes.DraftMovementController.onPageLoad(ern, testDraftId).url
       }
 
-      "must redirect to Task List when not all IR704 errors have been fixed" in new Test(
+      "must redirect to Task List when not all IE704 errors have been fixed" in new Test(
         baseFullUserAnswers.copy(submissionFailures = Seq(
           itemQuantityFailure(1),
           itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
@@ -205,18 +205,6 @@ class DeclarationControllerSpec extends SpecBase
 
       "when creating a request model fails" - {
         "must return a BadRequest when MissingMandatoryPage" in new Test(emptyUserAnswers) {
-          val res = controller.onSubmit(ern, testDraftId)(request)
-
-          status(res) mustBe SEE_OTHER
-          redirectLocation(res) mustBe Some(routes.DraftMovementController.onPageLoad(ern, testDraftId).url)
-        }
-
-        "must return a BadRequest when UnfixedSubmissionFailuresException (submission failures remain unfixed)" in new Test(
-          baseFullUserAnswers.copy(submissionFailures = Seq(
-            itemQuantityFailure(1).copy(hasBeenFixed = false),
-            itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
-          ))
-        ) {
           val res = controller.onSubmit(ern, testDraftId)(request)
 
           status(res) mustBe SEE_OTHER

--- a/test/controllers/DeclarationControllerSpec.scala
+++ b/test/controllers/DeclarationControllerSpec.scala
@@ -166,32 +166,30 @@ class DeclarationControllerSpec extends SpecBase
           redirectLocation(res) must contain(testOnwardRoute.url)
         }
 
-        //TODO: add in when ETFE-3340 frontend has been merged (impossible to fix error as of: 13/03/24)
-        //        "must save the timestamp and redirect (when all submission failures have been fixed)" in new Test(
-        //          baseFullUserAnswers.copy(
-        //            submissionFailures = Seq(
-        //              itemQuantityFailure(1).copy(hasBeenFixed = true),
-        //              itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
-        //            )
-        //          )
-        //        ) {
-        //          val expectedUserAnswers = baseFullUserAnswers.copy(
-        //            hasBeenSubmitted = true,
-        //            submittedDraftId = Some(testDraftId),
-        //            submissionFailures = Seq(
-        //              itemQuantityFailure(1).copy(hasBeenFixed = true),
-        //              itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
-        //            ))
-        //          MockAppConfig.destinationOfficeSuffix.returns("004098")
-        //          MockSubmitCreateMovementService.submit(xircSubmitCreateMovementModel).returns(Future.successful(submitCreateMovementResponseEIS))
-        //          MockUserAnswersService.set(expectedUserAnswers).returns(Future.successful(expectedUserAnswers))
-        //
-        //          val res = controller.onSubmit(ern, testDraftId)(request)
-        //
-        //          status(res) mustBe SEE_OTHER
-        //          redirectLocation(res) must contain(testOnwardRoute.url)
-        //        }
-        //      }
+        "must save the timestamp and redirect (when all submission failures have been fixed)" in new Test(
+          baseFullUserAnswers.copy(
+            submissionFailures = Seq(
+              itemQuantityFailure(1).copy(hasBeenFixed = true),
+              itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
+            )
+          )
+        ) {
+          val expectedUserAnswers = baseFullUserAnswers.copy(
+            hasBeenSubmitted = true,
+            submittedDraftId = Some(testDraftId),
+            submissionFailures = Seq(
+              itemQuantityFailure(1).copy(hasBeenFixed = true),
+              itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
+            ))
+          MockAppConfig.destinationOfficeSuffix.returns("004098")
+          MockSubmitCreateMovementService.submit(xircSubmitCreateMovementModel).returns(Future.successful(submitCreateMovementResponseEIS))
+          MockUserAnswersService.set(expectedUserAnswers).returns(Future.successful(expectedUserAnswers))
+
+          val res = controller.onSubmit(ern, testDraftId)(request)
+
+          status(res) mustBe SEE_OTHER
+          redirectLocation(res) must contain(testOnwardRoute.url)
+        }
       }
 
       "when downstream call is unsuccessful" - {
@@ -212,18 +210,18 @@ class DeclarationControllerSpec extends SpecBase
           status(res) mustBe SEE_OTHER
           redirectLocation(res) mustBe Some(routes.DraftMovementController.onPageLoad(ern, testDraftId).url)
         }
-        //TODO: add in when ETFE-3340 frontend has been merged (impossible to fix error as of: 13/03/24)
-        //        "must return a BadRequest when UnfixedSubmissionFailuresException (submission failures remain unfixed)" in new Test(
-        //          baseFullUserAnswers.copy(submissionFailures = Seq(
-        //            itemQuantityFailure(1).copy(hasBeenFixed = false),
-        //            itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
-        //          ))
-        //        ) {
-        //          val res = controller.onSubmit(ern, testDraftId)(request)
-        //
-        //          status(res) mustBe SEE_OTHER
-        //          redirectLocation(res) mustBe Some(routes.DraftMovementController.onPageLoad(ern, testDraftId).url)
-        //        }
+
+        "must return a BadRequest when UnfixedSubmissionFailuresException (submission failures remain unfixed)" in new Test(
+          baseFullUserAnswers.copy(submissionFailures = Seq(
+            itemQuantityFailure(1).copy(hasBeenFixed = false),
+            itemDegreesPlatoFailure(2).copy(hasBeenFixed = true)
+          ))
+        ) {
+          val res = controller.onSubmit(ern, testDraftId)(request)
+
+          status(res) mustBe SEE_OTHER
+          redirectLocation(res) mustBe Some(routes.DraftMovementController.onPageLoad(ern, testDraftId).url)
+        }
 
         "must return a InternalServerError when something else goes wrong" in new Test() {
           MockAppConfig.destinationOfficeSuffix.throws(new Exception("test error"))

--- a/test/controllers/sections/items/ItemSmallIndependentProducerControllerSpec.scala
+++ b/test/controllers/sections/items/ItemSmallIndependentProducerControllerSpec.scala
@@ -20,12 +20,17 @@ import base.SpecBase
 import controllers.actions.FakeDataRetrievalAction
 import fixtures.ItemFixtures
 import forms.sections.items.ItemSmallIndependentProducerFormProvider
+import forms.sections.items.ItemSmallIndependentProducerFormProvider.{producerField, producerIdField}
 import mocks.services.MockUserAnswersService
-import models.GoodsType.Wine
+import models.sections.info.movementScenario.MovementScenario.GbTaxWarehouse
+import models.sections.items.ItemSmallIndependentProducerModel
+import models.sections.items.ItemSmallIndependentProducerType.{SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.{Index, NormalMode, UserAnswers}
 import navigation.FakeNavigators.FakeItemsNavigator
-import pages.sections.items.{ItemExciseProductCodePage, ItemProducerSizePage, ItemSmallIndependentProducerPage}
-import play.api.mvc.AnyContentAsEmpty
+import pages.sections.info.DestinationTypePage
+import pages.sections.items.{ItemCommodityCodePage, ItemExciseProductCodePage, ItemProducerSizePage, ItemSmallIndependentProducerPage}
+import play.api.data.Form
+import play.api.mvc.{AnyContentAsEmpty, Call}
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
 import views.html.sections.items.ItemSmallIndependentProducerView
@@ -34,20 +39,31 @@ import scala.concurrent.Future
 
 class ItemSmallIndependentProducerControllerSpec extends SpecBase with MockUserAnswersService with ItemFixtures {
 
-  //Ensures a dummy item exists in the array for testing
-  val defaultUserAnswers = emptyUserAnswers.set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+  val defaultUserAnswers: UserAnswers = {
+    emptyUserAnswers
+      .set(DestinationTypePage, GbTaxWarehouse)
+      .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+      .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+  }
 
-  def itemSmallIndependentProducerSubmitAction(idx: Index = testIndex1) =
+  def itemSmallIndependentProducerSubmitAction(idx: Index = testIndex1): Call =
     routes.ItemSmallIndependentProducerController.onSubmit(testErn, testDraftId, idx, NormalMode)
 
+  val model: ItemSmallIndependentProducerModel = ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testVatNumber))
+
+  val validFormBody: Seq[(String, String)] = Seq(
+    producerField -> SelfCertifiedIndependentSmallProducerAndNotConsignor.toString,
+    producerIdField -> testVatNumber
+  )
+
+  lazy val formProvider = new ItemSmallIndependentProducerFormProvider()
+  lazy val form: Form[ItemSmallIndependentProducerModel] = formProvider()
+
+  lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+
+  lazy val view: ItemSmallIndependentProducerView = app.injector.instanceOf[ItemSmallIndependentProducerView]
+
   class Test(val userAnswers: Option[UserAnswers] = Some(defaultUserAnswers)) {
-
-    lazy val formProvider = new ItemSmallIndependentProducerFormProvider()
-    lazy val form = formProvider()
-
-    lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-
-    lazy val view = app.injector.instanceOf[ItemSmallIndependentProducerView]
 
     lazy val controller = new ItemSmallIndependentProducerController(
       messagesApi,
@@ -83,41 +99,48 @@ class ItemSmallIndependentProducerControllerSpec extends SpecBase with MockUserA
       val result = controller.onPageLoad(testErn, testDraftId, testIndex1, NormalMode)(request)
 
       status(result) mustEqual OK
-      contentAsString(result) mustEqual view(form, itemSmallIndependentProducerSubmitAction(), Wine)(dataRequest(request), messages(request)).toString
+      contentAsString(result) mustEqual
+        view(
+          form,
+          itemSmallIndependentProducerSubmitAction(),
+          testIndex1
+        )(dataRequest(request, userAnswers.get), messages(request)).toString
     }
 
     "must populate the view correctly on a GET when the question has previously been answered" in new Test(Some(
-      defaultUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true)
+      defaultUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), model)
     )) {
       val result = controller.onPageLoad(testErn, testDraftId, testIndex1, NormalMode)(request)
 
       status(result) mustEqual OK
       contentAsString(result) mustEqual view(
-        form.fill(true),
+        form.fill(model),
         itemSmallIndependentProducerSubmitAction(),
-        Wine
+        testIndex1
       )(dataRequest(request, userAnswers.get), messages(request)).toString
     }
 
     "must redirect to the next page when valid data is submitted" - {
       "when the answer has changed" in new Test(Some(
         defaultUserAnswers
-          .set(ItemSmallIndependentProducerPage(testIndex1), false)
+          .set(ItemSmallIndependentProducerPage(testIndex1), model.copy(SelfCertifiedIndependentSmallProducerAndConsignor, producerId = None))
           .set(ItemProducerSizePage(testIndex1), BigInt(1))
       )) {
-        MockUserAnswersService.set(defaultUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true)).returns(Future.successful(emptyUserAnswers))
+        MockUserAnswersService
+          .set(defaultUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), model.copy(SelfCertifiedIndependentSmallProducerAndNotConsignor, producerId = Some(testVatNumber))))
+          .returns(Future.successful(emptyUserAnswers))
 
-        val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "true")))
+        val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(validFormBody: _*))
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual testOnwardRoute.url
       }
       "when the answer has not changed" in new Test(Some(
         defaultUserAnswers
-          .set(ItemSmallIndependentProducerPage(testIndex1), true)
+          .set(ItemSmallIndependentProducerPage(testIndex1), model)
           .set(ItemProducerSizePage(testIndex1), BigInt(1))
       )) {
-        val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "true")))
+        val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(validFormBody: _*))
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual testOnwardRoute.url
@@ -127,22 +150,34 @@ class ItemSmallIndependentProducerControllerSpec extends SpecBase with MockUserA
       )) {
         MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
-        val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "true")))
+        val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(validFormBody: _*))
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual testOnwardRoute.url
       }
     }
 
-    "must render BadRequest when invalid data is submitted" in new Test() {
-      val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "")))
-      val boundForm = form.bind(Map("value" -> ""))
+    s"must render BadRequest when $SelfCertifiedIndependentSmallProducerAndNotConsignor is selected but no identifier is entered" in new Test() {
+      val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(validFormBody.head))
+      val boundForm = form.bind(Map(validFormBody.head))
 
       status(result) mustEqual BAD_REQUEST
       contentAsString(result) mustEqual view(
         boundForm,
         itemSmallIndependentProducerSubmitAction(),
-        Wine
+        testIndex1
+      )(dataRequest(request, userAnswers.get), messages(request)).toString
+    }
+
+    "must render BadRequest when no option is selected" in new Test() {
+      val result = controller.onSubmit(testErn, testDraftId, testIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "")))
+      val boundForm = form.bind(Map(producerField -> ""))
+
+      status(result) mustEqual BAD_REQUEST
+      contentAsString(result) mustEqual view(
+        boundForm,
+        itemSmallIndependentProducerSubmitAction(),
+        testIndex1
       )(dataRequest(request, userAnswers.get), messages(request)).toString
     }
 

--- a/test/controllers/sections/items/ItemSmallIndependentProducerControllerSpec.scala
+++ b/test/controllers/sections/items/ItemSmallIndependentProducerControllerSpec.scala
@@ -22,7 +22,7 @@ import fixtures.ItemFixtures
 import forms.sections.items.ItemSmallIndependentProducerFormProvider
 import forms.sections.items.ItemSmallIndependentProducerFormProvider.{producerField, producerIdField}
 import mocks.services.MockUserAnswersService
-import models.sections.info.movementScenario.MovementScenario.GbTaxWarehouse
+import models.sections.info.movementScenario.MovementScenario.UkTaxWarehouse
 import models.sections.items.ItemSmallIndependentProducerModel
 import models.sections.items.ItemSmallIndependentProducerType.{SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.{Index, NormalMode, UserAnswers}
@@ -41,7 +41,7 @@ class ItemSmallIndependentProducerControllerSpec extends SpecBase with MockUserA
 
   val defaultUserAnswers: UserAnswers = {
     emptyUserAnswers
-      .set(DestinationTypePage, GbTaxWarehouse)
+      .set(DestinationTypePage, UkTaxWarehouse.GB)
       .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
       .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
   }

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -354,4 +354,32 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
       normaliseSpacesAndControlCharacters("foo   \n   \r   bar") mustBe "foo bar"
     }
   }
+
+  "isOptionSelected" - {
+
+    val optionField = "optionField"
+
+    val optionValue = "optionValue"
+
+    "must return true" - {
+
+      "when the option has been selected" in {
+
+        isOptionSelected(optionField, optionValue).apply(Map(optionField -> optionValue)) mustBe true
+      }
+    }
+
+    "must return false" - {
+
+      "when the option has not been selected" in {
+
+        isOptionSelected(optionField, "blah").apply(Map(optionField -> optionValue)) mustBe false
+      }
+
+      "when the option value doesn't exist in the form data" in {
+
+        isOptionSelected(optionField, optionValue).apply(Map.empty) mustBe false
+      }
+    }
+  }
 }

--- a/test/models/sections/items/ItemSmallIndependentProducerTypeSpec.scala
+++ b/test/models/sections/items/ItemSmallIndependentProducerTypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,18 @@
 package models.sections.items
 
 import base.SpecBase
-import models.sections.items.ItemGeographicalIndicationType._
+import models.sections.items.ItemSmallIndependentProducerType._
 
-class ItemGeographicalIndicationTypeSpec extends SpecBase {
+class ItemSmallIndependentProducerTypeSpec extends SpecBase {
 
   ".values" - {
     "should return all the geographical indication options" in {
-      ItemGeographicalIndicationType.values mustBe Seq(
-        ProtectedDesignationOfOrigin, ProtectedGeographicalIndication, NoGeographicalIndication
+      ItemSmallIndependentProducerType.values mustBe Seq(
+        CertifiedIndependentSmallProducer,
+        SelfCertifiedIndependentSmallProducerAndConsignor,
+        SelfCertifiedIndependentSmallProducerAndNotConsignor,
+        NotAIndependentSmallProducer,
+        NotProvided
       )
     }
   }

--- a/test/models/submitCreateMovement/BodyEadEsadModelSpec.scala
+++ b/test/models/submitCreateMovement/BodyEadEsadModelSpec.scala
@@ -19,13 +19,15 @@ package models.submitCreateMovement
 import base.SpecBase
 import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
-import models.GoodsType
 import models.requests.DataRequest
 import models.response.MissingMandatoryPage
 import models.response.referenceData.{ItemPackaging, WineOperations}
+import models.sections.info.movementScenario.MovementScenario.{EuTaxWarehouse, GbTaxWarehouse, UnknownDestination}
 import models.sections.items.ItemGeographicalIndicationType.{NoGeographicalIndication, ProtectedDesignationOfOrigin, ProtectedGeographicalIndication}
+import models.sections.items.ItemSmallIndependentProducerType.{CertifiedIndependentSmallProducer, NotProvided, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.sections.items.ItemWineProductCategory.ImportedWine
 import models.sections.items._
+import pages.sections.info.DestinationTypePage
 import pages.sections.items._
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
@@ -57,6 +59,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           FakeRequest(),
           emptyUserAnswers
+            .set(DestinationTypePage, GbTaxWarehouse)
             .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
             .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
             .set(ItemQuantityPage(testIndex1), BigDecimal(1))
@@ -66,7 +69,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
             .set(ItemFiscalMarksPage(testIndex1), "fiscal marks")
             .set(ItemFiscalMarksChoicePage(testIndex1), true)
             .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(ProtectedDesignationOfOrigin, Some("talkin' 'bout my deeeeeesignation"), None))
-            .set(ItemSmallIndependentProducerPage(testIndex1), true)
+            .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(CertifiedIndependentSmallProducer, None))
             .set(ItemProducerSizePage(testIndex1), BigInt(4))
             .set(ItemDensityPage(testIndex1), BigDecimal(7.89))
             .set(ItemCommercialDescriptionPage(testIndex1), "beans")
@@ -94,7 +97,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
           fiscalMark = Some("fiscal marks"),
           fiscalMarkUsedFlag = Some(true),
           designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-          independentSmallProducersDeclaration = Some("It is hereby certified that the product described has been produced by an independent small wine producer"),
+          independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent small producer. The producer is a certified independent small producer"),
           sizeOfProducer = Some(BigInt(4)),
           density = Some(BigDecimal(7.89)),
           commercialDescription = Some("beans"),
@@ -124,6 +127,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           FakeRequest(),
           emptyUserAnswers
+            .set(DestinationTypePage, EuTaxWarehouse)
             .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
             .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
             .set(ItemQuantityPage(testIndex1), BigDecimal(1))
@@ -133,7 +137,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
             .set(ItemFiscalMarksPage(testIndex1), "fiscal marks")
             .set(ItemFiscalMarksChoicePage(testIndex1), true)
             .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(ProtectedDesignationOfOrigin, Some("talkin' 'bout my deeeeeesignation"), None))
-            .set(ItemSmallIndependentProducerPage(testIndex1), true)
+            .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
             .set(ItemProducerSizePage(testIndex1), BigInt(4))
             .set(ItemDensityPage(testIndex1), BigDecimal(7.89))
             .set(ItemCommercialDescriptionPage(testIndex1), "beans")
@@ -151,7 +155,8 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
             .set(ItemWineGrowingZonePage(testIndex1), ItemWineGrowingZone.CII)
             .set(ItemWineOriginPage(testIndex1), countryModelGB)
             .set(ItemWineMoreInformationPage(testIndex1), Some("more wine info"))
-            .set(ItemWineOperationsChoicePage(testIndex1), Seq(WineOperations("op code", "choice desc")))
+            .set(ItemWineOperationsChoicePage(testIndex1), Seq(WineOperations("op code", "choice desc"))),
+          ern = testNorthernIrelandErn
         )
 
         BodyEadEsadModel.apply mustBe Seq(BodyEadEsadModel(
@@ -166,7 +171,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
           fiscalMark = Some("fiscal marks"),
           fiscalMarkUsedFlag = Some(true),
           designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-          independentSmallProducersDeclaration = Some("It is hereby certified that the product described has been produced by an independent small wine producer"),
+          independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent wine producer. The producer is a self-certified independent small producer and not the consignor. Seed number: XIRC123456789"),
           sizeOfProducer = Some(BigInt(4)),
           density = Some(BigDecimal(7.89)),
           commercialDescription = Some("beans"),
@@ -203,6 +208,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           FakeRequest(),
           emptyUserAnswers
+            .set(DestinationTypePage, GbTaxWarehouse)
             // index 1
             .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
             .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
@@ -213,7 +219,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
             .set(ItemFiscalMarksPage(testIndex1), "fiscal marks")
             .set(ItemFiscalMarksChoicePage(testIndex1), true)
             .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(ProtectedDesignationOfOrigin, Some("talkin' 'bout my deeeeeesignation"), None))
-            .set(ItemSmallIndependentProducerPage(testIndex1), true)
+            .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(NotProvided, None))
             .set(ItemProducerSizePage(testIndex1), BigInt(4))
             .set(ItemDensityPage(testIndex1), BigDecimal(7.89))
             .set(ItemCommercialDescriptionPage(testIndex1), "beans")
@@ -266,7 +272,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
             fiscalMark = Some("fiscal marks"),
             fiscalMarkUsedFlag = Some(true),
             designationOfOrigin = Some("The product has a Protected Designation of Origin (PDO). talkin' 'bout my deeeeeesignation"),
-            independentSmallProducersDeclaration = Some("It is hereby certified that the product described has been produced by an independent small wine producer"),
+            independentSmallProducersDeclaration = Some("It is hereby certified that the alcoholic product described has been produced by an independent small producer. I don't want to provide information about the producer"),
             sizeOfProducer = Some(BigInt(4)),
             density = Some(BigDecimal(7.89)),
             commercialDescription = Some("beans"),
@@ -425,107 +431,92 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
 
   "smallIndependentProducer" - {
 
-    s"when the $ItemSmallIndependentProducerPage answer is yes, return the generated answer" in {
+    s"when the $ItemSmallIndependentProducerPage answer is present, return the generated answer" in {
 
-      BodyEadEsadModel.smallIndependentProducer(testIndex1, testEpcBeer, testCnCodeBeer)(dataRequest(FakeRequest(),
-        emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true)
-      ), implicitly) mustBe Some("It is hereby certified that the product described has been produced by an independent small brewery")
-    }
-
-    s"when the $ItemSmallIndependentProducerPage answer is no, return None" in {
-
-      BodyEadEsadModel.smallIndependentProducer(testIndex1, testEpcBeer, testCnCodeBeer)(dataRequest(FakeRequest(),
-        emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), false)
-      ), implicitly) mustBe None
+      BodyEadEsadModel.smallIndependentProducer(testIndex1)(dataRequest(FakeRequest(),
+        emptyUserAnswers
+          .set(DestinationTypePage, GbTaxWarehouse)
+          .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+          .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+          .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
+      ), implicitly) mustBe Some("It is hereby certified that the alcoholic product described has been produced by an independent small producer. The producer is a self-certified independent small producer and not the consignor. Seed number: XIRC123456789")
     }
 
     s"when the $ItemSmallIndependentProducerPage has no answer at the specified index, return None" in {
 
-      BodyEadEsadModel.smallIndependentProducer(testIndex2, testEpcBeer, testCnCodeBeer)(dataRequest(FakeRequest(),
-        emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true)
+      BodyEadEsadModel.smallIndependentProducer(testIndex2)(dataRequest(FakeRequest(),
+        emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
       ), implicitly) mustBe None
     }
 
     s"when the $ItemSmallIndependentProducerPage has no answer, return None" in {
 
-      BodyEadEsadModel.smallIndependentProducer(testIndex1, testEpcBeer, testCnCodeBeer)(dataRequest(FakeRequest()), implicitly) mustBe None
+      BodyEadEsadModel.smallIndependentProducer(testIndex1)(dataRequest(FakeRequest()), implicitly) mustBe None
     }
   }
 
-  "smallIndependentProducerYesAnswer" - {
-    "when XI trader" - {
-      Seq(
-        GoodsType.Beer -> messagesForLanguage.yesBeer,
-        GoodsType.Spirits -> messagesForLanguage.yesSpirits,
-        GoodsType.Wine -> messagesForLanguage.yesWine,
-        GoodsType.Energy -> messagesForLanguage.yesOther,
-        GoodsType.Tobacco -> messagesForLanguage.yesOther,
-        GoodsType.Intermediate -> messagesForLanguage.yesIntermediate
-      ).foreach {
-        case (goodsType, yesText) =>
-          s"when goodsType is [$goodsType] must return [$yesText]" in {
-            Seq("XIRC123", "XIWK123").foreach {
-              ern =>
-                implicit val dr: DataRequest[_] = dataRequest(
-                  fakeRequest,
-                  emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true),
-                  ern = ern
-                )
+  //Each scenario is independently tested within ItemSmallIndependentProducerHelperSpec so only smoke test
+  "smallIndependentProducerAnswer" - {
 
-                BodyEadEsadModel.smallIndependentProducerYesAnswer(goodsType) mustBe yesText
-            }
-          }
-      }
-      s"when goodsType is [${GoodsType.Fermented(GoodsType.fermentedBeverages.head).getClass.getName.stripSuffix("$")}]" +
-        s" must return [${messagesForLanguage.yesFermented}]" in {
-        Seq("XIRC123", "XIWK123").foreach {
-          ern =>
-            implicit val dr: DataRequest[_] = dataRequest(
-              fakeRequest,
-              emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true),
-              ern = ern
-            )
+    "generate the correct answer for GB / Exports" in {
 
-            BodyEadEsadModel.smallIndependentProducerYesAnswer(GoodsType.Fermented(GoodsType.fermentedBeverages.head)) mustBe messagesForLanguage.yesFermented
-        }
-      }
+      implicit val dr = dataRequest(FakeRequest(),
+        emptyUserAnswers
+          .set(DestinationTypePage, GbTaxWarehouse)
+          .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+          .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+          .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
+      )
+
+      BodyEadEsadModel.smallIndependentProducerAnswer(
+        testIndex1, ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn))
+      ) mustBe s"It is hereby certified that the alcoholic product described has been produced by an independent small producer. The producer is a self-certified independent small producer and not the consignor. Seed number: $testErn"
     }
-    "when GB trader" - {
-      Seq(
-        GoodsType.Beer -> messagesForLanguage.yesOther,
-        GoodsType.Spirits -> messagesForLanguage.yesOther,
-        GoodsType.Wine -> messagesForLanguage.yesOther,
-        GoodsType.Energy -> messagesForLanguage.yesOther,
-        GoodsType.Tobacco -> messagesForLanguage.yesOther,
-        GoodsType.Intermediate -> messagesForLanguage.yesOther
-      ).foreach {
-        case (goodsType, yesText) =>
-          s"when goodsType is [$goodsType] must return [$yesText]" in {
-            Seq("GBRC123", "GBWK123").foreach {
-              ern =>
-                implicit val dr: DataRequest[_] = dataRequest(
-                  fakeRequest,
-                  emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true),
-                  ern = ern
-                )
 
-                BodyEadEsadModel.smallIndependentProducerYesAnswer(goodsType) mustBe yesText
-            }
-          }
-      }
-      s"when goodsType is [${GoodsType.Fermented(GoodsType.fermentedBeverages.head).getClass.getName.stripSuffix("$")}]" +
-        s" must return [${messagesForLanguage.yesOther}]" in {
-        Seq("GBRC123", "GBWK123").foreach {
-          ern =>
-            implicit val dr: DataRequest[_] = dataRequest(
-              fakeRequest,
-              emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true),
-              ern = ern
-            )
+    "generate the correct answer when the user doesn't want to provide a small independent producer" in {
 
-            BodyEadEsadModel.smallIndependentProducerYesAnswer(GoodsType.Fermented(GoodsType.fermentedBeverages.head)) mustBe messagesForLanguage.yesOther
-        }
-      }
+      implicit val dr = dataRequest(FakeRequest(),
+        emptyUserAnswers
+          .set(DestinationTypePage, GbTaxWarehouse)
+          .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+          .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+          .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(NotProvided, None))
+      )
+
+      BodyEadEsadModel.smallIndependentProducerAnswer(
+        testIndex1, ItemSmallIndependentProducerModel(NotProvided, None)
+      ) mustBe s"It is hereby certified that the alcoholic product described has been produced by an independent small producer. I don't want to provide information about the producer"
+    }
+
+    "generate the correct answer for NI -> EU" in {
+
+      implicit val dr = dataRequest(FakeRequest(),
+        emptyUserAnswers
+          .set(DestinationTypePage, EuTaxWarehouse)
+          .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+          .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+          .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn))),
+        ern = testNorthernIrelandErn
+      )
+
+      BodyEadEsadModel.smallIndependentProducerAnswer(
+        testIndex1, ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn))
+      ) mustBe s"It is hereby certified that the alcoholic product described has been produced by an independent wine producer. The producer is a self-certified independent small producer and not the consignor. Seed number: $testErn"
+    }
+
+    "throw an exception on an invalid scenario" in {
+
+      implicit val dr = dataRequest(FakeRequest(),
+        emptyUserAnswers
+          .set(DestinationTypePage, UnknownDestination)
+          .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+          .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+          .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
+      )
+
+      intercept[IllegalStateException](
+        BodyEadEsadModel.smallIndependentProducerAnswer(testIndex1, ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
+      ).getMessage mustBe s"Invalid scenario for small independent producer. Destination type: Some($UnknownDestination) & EPC: Some($testEpcWine) & CN code: Some($testCnCodeWine)"
     }
   }
 }

--- a/test/models/submitCreateMovement/BodyEadEsadModelSpec.scala
+++ b/test/models/submitCreateMovement/BodyEadEsadModelSpec.scala
@@ -22,7 +22,7 @@ import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import models.requests.DataRequest
 import models.response.MissingMandatoryPage
 import models.response.referenceData.{ItemPackaging, WineOperations}
-import models.sections.info.movementScenario.MovementScenario.{EuTaxWarehouse, GbTaxWarehouse, UnknownDestination}
+import models.sections.info.movementScenario.MovementScenario.{EuTaxWarehouse, UkTaxWarehouse, UnknownDestination}
 import models.sections.items.ItemGeographicalIndicationType.{NoGeographicalIndication, ProtectedDesignationOfOrigin, ProtectedGeographicalIndication}
 import models.sections.items.ItemSmallIndependentProducerType.{CertifiedIndependentSmallProducer, NotProvided, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.sections.items.ItemWineProductCategory.ImportedWine
@@ -59,7 +59,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           FakeRequest(),
           emptyUserAnswers
-            .set(DestinationTypePage, GbTaxWarehouse)
+            .set(DestinationTypePage, UkTaxWarehouse.GB)
             .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
             .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
             .set(ItemQuantityPage(testIndex1), BigDecimal(1))
@@ -208,7 +208,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           FakeRequest(),
           emptyUserAnswers
-            .set(DestinationTypePage, GbTaxWarehouse)
+            .set(DestinationTypePage, UkTaxWarehouse.GB)
             // index 1
             .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
             .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
@@ -435,7 +435,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
 
       BodyEadEsadModel.smallIndependentProducer(testIndex1)(dataRequest(FakeRequest(),
         emptyUserAnswers
-          .set(DestinationTypePage, GbTaxWarehouse)
+          .set(DestinationTypePage, UkTaxWarehouse.GB)
           .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
           .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
           .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
@@ -462,7 +462,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
 
       implicit val dr = dataRequest(FakeRequest(),
         emptyUserAnswers
-          .set(DestinationTypePage, GbTaxWarehouse)
+          .set(DestinationTypePage, UkTaxWarehouse.GB)
           .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
           .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
           .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
@@ -477,7 +477,7 @@ class BodyEadEsadModelSpec extends SpecBase with ItemFixtures {
 
       implicit val dr = dataRequest(FakeRequest(),
         emptyUserAnswers
-          .set(DestinationTypePage, GbTaxWarehouse)
+          .set(DestinationTypePage, UkTaxWarehouse.GB)
           .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
           .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
           .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(NotProvided, None))

--- a/test/models/submitCreateMovement/SubmitCreateMovementModelSpec.scala
+++ b/test/models/submitCreateMovement/SubmitCreateMovementModelSpec.scala
@@ -22,6 +22,8 @@ import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import models.requests.DataRequest
 import models.sections.info._
+import models.sections.info.movementScenario.MovementScenario.GbTaxWarehouse
+import pages.sections.destination.{DestinationConsigneeDetailsPage, DestinationWarehouseExcisePage}
 import pages.sections.info._
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
@@ -130,7 +132,10 @@ class SubmitCreateMovementModelSpec extends SpecBase with ItemFixtures {
       "when GBRC" in {
         implicit val dr: DataRequest[_] = dataRequest(
           request = fakeRequest,
-          answers = baseFullUserAnswers,
+          answers = baseFullUserAnswers
+            .set(DestinationTypePage, GbTaxWarehouse)
+            .set(DestinationWarehouseExcisePage, testErn)
+            .set(DestinationConsigneeDetailsPage, false),
           ern = "GBRC123"
         )
 
@@ -139,7 +144,10 @@ class SubmitCreateMovementModelSpec extends SpecBase with ItemFixtures {
       "when GBWK" in {
         implicit val dr: DataRequest[_] = dataRequest(
           request = fakeRequest,
-          answers = baseFullUserAnswers,
+          answers = baseFullUserAnswers
+            .set(DestinationTypePage, GbTaxWarehouse)
+            .set(DestinationWarehouseExcisePage, testErn)
+            .set(DestinationConsigneeDetailsPage, false),
           ern = "GBWK123"
         )
 

--- a/test/models/submitCreateMovement/SubmitCreateMovementModelSpec.scala
+++ b/test/models/submitCreateMovement/SubmitCreateMovementModelSpec.scala
@@ -22,7 +22,7 @@ import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import models.requests.DataRequest
 import models.sections.info._
-import models.sections.info.movementScenario.MovementScenario.GbTaxWarehouse
+import models.sections.info.movementScenario.MovementScenario.UkTaxWarehouse
 import pages.sections.destination.{DestinationConsigneeDetailsPage, DestinationWarehouseExcisePage}
 import pages.sections.info._
 import play.api.i18n.Messages
@@ -133,7 +133,7 @@ class SubmitCreateMovementModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           request = fakeRequest,
           answers = baseFullUserAnswers
-            .set(DestinationTypePage, GbTaxWarehouse)
+            .set(DestinationTypePage, UkTaxWarehouse.GB)
             .set(DestinationWarehouseExcisePage, testErn)
             .set(DestinationConsigneeDetailsPage, false),
           ern = "GBRC123"
@@ -145,7 +145,7 @@ class SubmitCreateMovementModelSpec extends SpecBase with ItemFixtures {
         implicit val dr: DataRequest[_] = dataRequest(
           request = fakeRequest,
           answers = baseFullUserAnswers
-            .set(DestinationTypePage, GbTaxWarehouse)
+            .set(DestinationTypePage, UkTaxWarehouse.GB)
             .set(DestinationWarehouseExcisePage, testErn)
             .set(DestinationConsigneeDetailsPage, false),
           ern = "GBWK123"

--- a/test/navigation/ItemsNavigatorSpec.scala
+++ b/test/navigation/ItemsNavigatorSpec.scala
@@ -228,11 +228,24 @@ class ItemsNavigatorSpec extends SpecBase with ItemFixtures {
                   itemsRoutes.ItemSmallIndependentProducerController.onPageLoad(userAnswers.ern, userAnswers.draftId, testIndex1, NormalMode)
               }
             }
+
+            s"and the EPC is ${spiritEPC.code} and the ABV is >= 8.5" - {
+
+              "go to the Item Quantity Page" in {
+
+                val userAnswers = emptyUserAnswers.copy(ern = testGreatBritainErn)
+                  .set(ItemExciseProductCodePage(testIndex1), spiritEPC.code)
+                  .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.5))
+
+                navigator.nextPage(ItemAlcoholStrengthPage(testIndex1), NormalMode, userAnswers) mustBe
+                  itemsRoutes.ItemQuantityController.onPageLoad(userAnswers.ern, userAnswers.draftId, testIndex1, NormalMode)
+              }
+            }
           }
 
           "go to the Item Maturation Period Age Page" - {
 
-            "when the EPC is Spirituous Beverages" in {
+            "when the EPC is S200" in {
               val userAnswers = emptyUserAnswers.copy(ern = testGreatBritainErn)
                 .set(ItemExciseProductCodePage(testIndex1), testExciseProductCodeS200.code)
                 .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.5))

--- a/test/pages/sections/items/ItemsSectionItemSpec.scala
+++ b/test/pages/sections/items/ItemsSectionItemSpec.scala
@@ -23,6 +23,7 @@ import models.requests.DataRequest
 import models.response.referenceData.BulkPackagingType
 import models.sections.items.ItemBulkPackagingCode.BulkLiquid
 import models.sections.items.ItemGeographicalIndicationType.{NoGeographicalIndication, ProtectedDesignationOfOrigin}
+import models.sections.items.ItemSmallIndependentProducerType.{NotAIndependentSmallProducer, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.sections.items.ItemWineGrowingZone.CIII_A
 import models.sections.items.ItemWineProductCategory.{ImportedWine, Other}
 import models.sections.items._
@@ -654,7 +655,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
           .set(ItemBrandNamePage(testIndex1), ItemBrandNameModel(hasBrandName = true, Some("brand")))
           .set(ItemCommercialDescriptionPage(testIndex1), "Beer from hops")
           .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.4))
-          .set(ItemSmallIndependentProducerPage(testIndex1), true)
+          .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
           .set(ItemProducerSizePage(testIndex1), BigInt("300"))
           .set(ItemQuantityPage(testIndex1), BigDecimal("1000"))
           .set(ItemBulkPackagingChoicePage(testIndex1), false)
@@ -1075,7 +1076,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
           goodsType =>
             val userAnswers = emptyUserAnswers
               .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.49))
-              .set(ItemSmallIndependentProducerPage(testIndex1), true)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
@@ -1090,7 +1091,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
           goodsType =>
             val userAnswers = emptyUserAnswers
               .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.49))
-              .set(ItemSmallIndependentProducerPage(testIndex1), false)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(NotAIndependentSmallProducer, None))
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
@@ -1105,7 +1106,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
           goodsType =>
             val userAnswers = emptyUserAnswers
               .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.49))
-              .set(ItemSmallIndependentProducerPage(testIndex1), true)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
@@ -1117,7 +1118,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
           goodsType =>
             val userAnswers = emptyUserAnswers
               .set(ItemAlcoholStrengthPage(testIndex1), BigDecimal(8.5))
-              .set(ItemSmallIndependentProducerPage(testIndex1), true)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
@@ -1128,7 +1129,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
         GoodsType.values.filter(_.isAlcohol).foreach {
           goodsType =>
             val userAnswers = emptyUserAnswers
-              .set(ItemSmallIndependentProducerPage(testIndex1), true)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 

--- a/test/pages/sections/items/ItemsSectionItemSpec.scala
+++ b/test/pages/sections/items/ItemsSectionItemSpec.scala
@@ -18,7 +18,7 @@ package pages.sections.items
 
 import base.SpecBase
 import fixtures.{ItemFixtures, MovementSubmissionFailureFixtures}
-import models.GoodsType.{Beer, Energy}
+import models.GoodsType.{Beer, Energy, Spirits}
 import models.requests.DataRequest
 import models.response.referenceData.BulkPackagingType
 import models.sections.items.ItemBulkPackagingCode.BulkLiquid
@@ -967,27 +967,24 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
 
     "must return one item" - {
       "when alcohol, not beer, ItemDesignationOfOriginPage is NoGeographicalIndication" in {
-        GoodsType.values.filter(gt => gt.isAlcohol && (gt != Beer)).foreach {
+        GoodsType.values.filter(gt => gt.isAlcohol && gt != Beer && gt != Spirits).foreach {
           goodsType =>
             val userAnswers: UserAnswers = emptyUserAnswers
               .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(NoGeographicalIndication, None, None))
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
-            section.designationOfOriginAnswers(goodsType, dr).length mustBe 1
+            section.designationOfOriginAnswers(goodsType.code)(goodsType, dr).length mustBe 1
         }
       }
 
-      "when alcohol, not beer, ItemDesignationOfOriginPage is NoGeographicalIndication (S200)" in {
-        GoodsType.values.filter(gt => gt.isAlcohol && (gt != Beer)).foreach {
-          goodsType =>
-            val userAnswers: UserAnswers = emptyUserAnswers
-              .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(NoGeographicalIndication, None, isSpiritMarketedAndLabelled = Some(true)))
+      "when Spirits, not beer, ItemDesignationOfOriginPage is NoGeographicalIndication (S200)" in {
+          val userAnswers: UserAnswers = emptyUserAnswers
+            .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(NoGeographicalIndication, None, isSpiritMarketedAndLabelled = Some(true)))
 
-            val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
+          val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
-            section.designationOfOriginAnswers(goodsType, dr).length mustBe 1
-        }
+          section.designationOfOriginAnswers(testEpcSpirit)(Spirits, dr).length mustBe 1
       }
     }
 
@@ -1000,7 +997,7 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
 
             val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
-            section.designationOfOriginAnswers(goodsType, dr) mustBe Nil
+            section.designationOfOriginAnswers(goodsType.code)(goodsType, dr) mustBe Nil
         }
       }
 
@@ -1010,7 +1007,16 @@ class ItemsSectionItemSpec extends SpecBase with ItemFixtures with MovementSubmi
 
         val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
 
-        section.designationOfOriginAnswers(Beer, dr) mustBe Nil
+        section.designationOfOriginAnswers(testEpcBeer)(Beer, dr) mustBe Nil
+      }
+
+      "when Spirits (non-S200)" in {
+        val userAnswers: UserAnswers = emptyUserAnswers
+          .set(ItemDesignationOfOriginPage(testIndex1), ItemDesignationOfOriginModel(NoGeographicalIndication, None, None))
+
+        val dr: DataRequest[_] = dataRequest(FakeRequest(), userAnswers)
+
+        section.designationOfOriginAnswers(testExciseProductCodeS300.code)(Spirits, dr) mustBe Nil
       }
     }
   }

--- a/test/utils/ExciseProductCodeHelperSpec.scala
+++ b/test/utils/ExciseProductCodeHelperSpec.scala
@@ -29,7 +29,25 @@ class ExciseProductCodeHelperSpec extends SpecBase {
 
     "must return false" - {
       "when the epc is NOT S200" in {
-        ExciseProductCodeHelper.isSpirituousBeverages("S201") mustBe false
+        ExciseProductCodeHelper.isSpirituousBeverages("S300") mustBe false
+      }
+    }
+  }
+
+  ".isSpiritAndNotSpirituousBeverages" - {
+    "must return true" - {
+
+      Seq("S300", "S400", "S500", "S600").foreach { epc =>
+        s"when the epc is $epc" in {
+          ExciseProductCodeHelper.isSpiritAndNotSpirituousBeverages(epc) mustBe true
+        }
+      }
+      
+    }
+
+    "must return false" - {
+      "when the epc is NOT S300 / S400 / S500 / S600" in {
+        ExciseProductCodeHelper.isSpiritAndNotSpirituousBeverages("S200") mustBe false
       }
     }
   }

--- a/test/viewmodels/checkAnswers/sections/items/ItemProducerSizeSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/items/ItemProducerSizeSummarySpec.scala
@@ -19,6 +19,8 @@ package viewmodels.checkAnswers.sections.items
 import base.SpecBase
 import fixtures.messages.sections.items.ItemProducerSizeMessages
 import models.requests.DataRequest
+import models.sections.items.ItemSmallIndependentProducerType.{SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor}
+import models.sections.items.{ItemSmallIndependentProducerModel, ItemSmallIndependentProducerType}
 import models.{CheckMode, UserAnswers}
 import org.scalatest.matchers.must.Matchers
 import pages.sections.items.{ItemProducerSizePage, ItemSmallIndependentProducerPage}
@@ -42,39 +44,48 @@ class ItemProducerSizeSummarySpec extends SpecBase with Matchers {
 
       implicit lazy val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-      "if ItemSmallIndependentProducerPage is true" - {
-        "must return a row when there is an answer" in new Test(
-          emptyUserAnswers
-            .set(ItemSmallIndependentProducerPage(testIndex1), true)
-            .set(ItemProducerSizePage(testIndex1), BigInt(3))
-        ) {
-          ItemProducerSizeSummary.row(
-            idx = testIndex1
-          ) mustBe
-            Some(summaryListRowBuilder(
-              key = messagesForLanguage.cyaLabel,
-              value = s"3 ${messagesForLanguage.inputSuffix}",
-              changeLink = Some(ActionItemViewModel(
-                href = controllers.sections.items.routes.ItemProducerSizeController.onPageLoad(testErn, testDraftId, testIndex1, CheckMode).url,
-                content = messagesForLanguage.change,
-                id = s"changeItemProducerSize${testIndex1.displayIndex}"
-              ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden))
-            ))
+      Seq(SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor).foreach { producer =>
+
+        s"if ItemSmallIndependentProducerPage is $producer" - {
+          "must return a row when there is an answer" in new Test(
+            emptyUserAnswers
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(producer, Some(testErn)))
+              .set(ItemProducerSizePage(testIndex1), BigInt(3))
+          ) {
+            ItemProducerSizeSummary.row(
+              idx = testIndex1
+            ) mustBe
+              Some(summaryListRowBuilder(
+                key = messagesForLanguage.cyaLabel,
+                value = s"3 ${messagesForLanguage.inputSuffix}",
+                changeLink = Some(ActionItemViewModel(
+                  href = controllers.sections.items.routes.ItemProducerSizeController.onPageLoad(testErn, testDraftId, testIndex1, CheckMode).url,
+                  content = messagesForLanguage.change,
+                  id = s"changeItemProducerSize${testIndex1.displayIndex}"
+                ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden))
+              ))
+          }
         }
       }
-      "if ItemSmallIndependentProducerPage is false" - {
-        "must not return a row" in new Test(
-          emptyUserAnswers
-            .set(ItemSmallIndependentProducerPage(testIndex1), false)
-            .set(ItemProducerSizePage(testIndex1), BigInt(3))
-        ) {
-          ItemProducerSizeSummary.row(
-            idx = testIndex1
-          ) mustBe None
+
+      ItemSmallIndependentProducerType.values.diff(
+        Seq(SelfCertifiedIndependentSmallProducerAndConsignor, SelfCertifiedIndependentSmallProducerAndNotConsignor)
+      ).foreach { producer =>
+
+        s"if ItemSmallIndependentProducerPage is $producer" - {
+          "must not return a row" in new Test(
+            emptyUserAnswers
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(producer, Some(testErn)))
+              .set(ItemProducerSizePage(testIndex1), BigInt(3))
+          ) {
+            ItemProducerSizeSummary.row(idx = testIndex1) mustBe None
+          }
         }
       }
+
       "if not provided" - {
-        "must not return a row" in new Test(emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1), true)) {
+        "must not return a row" in new Test(emptyUserAnswers.set(ItemSmallIndependentProducerPage(testIndex1),
+          ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndConsignor, Some(testErn)))) {
           ItemProducerSizeSummary.row(
             idx = testIndex1
           ) mustBe None

--- a/test/viewmodels/checkAnswers/sections/items/ItemSmallIndependentProducerSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/items/ItemSmallIndependentProducerSummarySpec.scala
@@ -21,7 +21,7 @@ import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import models.GoodsType._
 import models.requests.DataRequest
-import models.sections.info.movementScenario.MovementScenario.{EuTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheEu, ExportWithCustomsDeclarationLodgedInTheUk, GbTaxWarehouse}
+import models.sections.info.movementScenario.MovementScenario.{EuTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheEu, ExportWithCustomsDeclarationLodgedInTheUk, UkTaxWarehouse}
 import models.sections.items.ItemSmallIndependentProducerModel
 import models.sections.items.ItemSmallIndependentProducerType.{CertifiedIndependentSmallProducer, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.{CheckMode, UserAnswers}
@@ -56,7 +56,12 @@ class ItemSmallIndependentProducerSummarySpec extends SpecBase with Matchers wit
 
         "return the correct row for" - {
 
-          Seq(GbTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheUk, ExportWithCustomsDeclarationLodgedInTheEu).foreach { movementScenario =>
+          Seq(
+            UkTaxWarehouse.GB,
+            UkTaxWarehouse.NI,
+            ExportWithCustomsDeclarationLodgedInTheUk,
+            ExportWithCustomsDeclarationLodgedInTheEu
+          ).foreach { movementScenario =>
 
             s"intra-UK / export movement: $movementScenario" in new Test(emptyUserAnswers
               .set(DestinationTypePage, movementScenario)

--- a/test/viewmodels/checkAnswers/sections/items/ItemSmallIndependentProducerSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/items/ItemSmallIndependentProducerSummarySpec.scala
@@ -17,24 +17,36 @@
 package viewmodels.checkAnswers.sections.items
 
 import base.SpecBase
+import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
+import models.GoodsType._
 import models.requests.DataRequest
+import models.sections.info.movementScenario.MovementScenario.{EuTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheEu, ExportWithCustomsDeclarationLodgedInTheUk, GbTaxWarehouse}
+import models.sections.items.ItemSmallIndependentProducerModel
+import models.sections.items.ItemSmallIndependentProducerType.{CertifiedIndependentSmallProducer, SelfCertifiedIndependentSmallProducerAndNotConsignor}
 import models.{CheckMode, UserAnswers}
 import org.scalatest.matchers.must.Matchers
-import pages.sections.items.ItemSmallIndependentProducerPage
+import pages.sections.info.DestinationTypePage
+import pages.sections.items.{ItemCommodityCodePage, ItemExciseProductCodePage, ItemSmallIndependentProducerPage}
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
+import uk.gov.hmrc.govukfrontend.views.Aliases.{HtmlContent, Text, Value}
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
+import views.html.components.p
 
-class ItemSmallIndependentProducerSummarySpec extends SpecBase with Matchers {
+class ItemSmallIndependentProducerSummarySpec extends SpecBase with Matchers with ItemFixtures {
 
-  class Test(val userAnswers: UserAnswers) {
-    implicit lazy val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+  val p: p = app.injector.instanceOf[p]
+
+  val summary: ItemSmallIndependentProducerSummary = app.injector.instanceOf[ItemSmallIndependentProducerSummary]
+
+  class Test(val userAnswers: UserAnswers, ern: String = testErn) {
+    implicit lazy val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers, ern = ern)
   }
 
-  "ItemSmallIndependentProducerSummarySummary" - {
+  "ItemSmallIndependentProducerSummary" - {
 
     Seq(ItemSmallIndependentProducerMessages.English).foreach { messagesForLanguage =>
 
@@ -42,47 +54,97 @@ class ItemSmallIndependentProducerSummarySpec extends SpecBase with Matchers {
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        "if true" - {
-          "must return a row" in new Test(
-            emptyUserAnswers
-              .set(ItemSmallIndependentProducerPage(testIndex1), true)
+        "return the correct row for" - {
+
+          Seq(GbTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheUk, ExportWithCustomsDeclarationLodgedInTheEu).foreach { movementScenario =>
+
+            s"intra-UK / export movement: $movementScenario" in new Test(emptyUserAnswers
+              .set(DestinationTypePage, movementScenario)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
+            ) {
+
+              summary.row(
+                idx = testIndex1
+              ) mustBe
+                Some(SummaryListRowViewModel(
+                  key = messagesForLanguage.cyaLabel,
+                  value = Value(HtmlContent(Seq(
+                    p()(Text(messagesForLanguage.producedByIndependentSmallProducer.dropRight(1)).asHtml).toString(),
+                    p()(Text(messagesForLanguage.selfCertifiedIndependentSmallProducerNotConsignor).asHtml).toString(),
+                    p()(Text(messagesForLanguage.seedNumber(testErn)).asHtml).toString()
+                  ).mkString)),
+                  actions = Seq(ActionItemViewModel(
+                    href = controllers.sections.items.routes.ItemSmallIndependentProducerController.onPageLoad(testErn, testDraftId, testIndex1, CheckMode).url,
+                    content = messagesForLanguage.change,
+                    id = s"changeItemSmallIndependentProducer${testIndex1.displayIndex}"
+                  ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden))
+                ))
+            }
+
+          }
+
+          Seq(
+            Beer -> messagesForLanguage.producedByIndependentSmallBrewery,
+            Spirits -> messagesForLanguage.producedByIndependentSmallDistillery,
+            Wine -> messagesForLanguage.producedByIndependentWineProducer,
+            Intermediate -> messagesForLanguage.producedByIndependentIntermediateProductsProducer
+          ).foreach { goodsTypeAndDeclaration =>
+
+            s"NI -> EU movement and goods type: ${goodsTypeAndDeclaration._1}" in new Test(emptyUserAnswers
+              .set(DestinationTypePage, EuTaxWarehouse)
+              .set(ItemExciseProductCodePage(testIndex1), goodsTypeAndDeclaration._1.code)
+              .set(ItemCommodityCodePage(testIndex1), testCnCodeBeer) //Irrelevant for these scenarios (but logically required)
+              .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(CertifiedIndependentSmallProducer, None)
+              ), ern = testNorthernIrelandErn
+            ) {
+
+              summary.row(
+                idx = testIndex1
+              ) mustBe
+                Some(SummaryListRowViewModel(
+                  key = messagesForLanguage.cyaLabel,
+                  value = Value(HtmlContent(Seq(
+                    p()(Text(goodsTypeAndDeclaration._2.dropRight(1)).asHtml).toString(),
+                    p()(Text(messagesForLanguage.certifiedIndependentSmallProducer).asHtml).toString()
+                  ).mkString)),
+                  actions = Seq(ActionItemViewModel(
+                    href = controllers.sections.items.routes.ItemSmallIndependentProducerController.onPageLoad(testNorthernIrelandErn, testDraftId, testIndex1, CheckMode).url,
+                    content = messagesForLanguage.change,
+                    id = s"changeItemSmallIndependentProducer${testIndex1.displayIndex}"
+                  ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden))
+                ))
+            }
+          }
+
+          s"NI -> EU movement and goods type: $Fermented" in new Test(emptyUserAnswers
+            .set(DestinationTypePage, EuTaxWarehouse)
+            .set(ItemExciseProductCodePage(testIndex1), Fermented(testEpcWine).code)
+            .set(ItemCommodityCodePage(testIndex1), testCnCodeSpirit)
+            .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(CertifiedIndependentSmallProducer, None)
+            ), ern = testNorthernIrelandErn
           ) {
-            ItemSmallIndependentProducerSummary.row(
+
+            summary.row(
               idx = testIndex1
             ) mustBe
-              Some(summaryListRowBuilder(
+              Some(SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
-                value = messagesForLanguage.yes,
-                changeLink = Some(ActionItemViewModel(
-                  href = controllers.sections.items.routes.ItemSmallIndependentProducerController.onPageLoad(testErn, testDraftId, testIndex1, CheckMode).url,
+                value = Value(HtmlContent(Seq(
+                  p()(Text(messagesForLanguage.producedByIndependentFermentedBeveragesProducer.dropRight(1)).asHtml).toString(),
+                  p()(Text(messagesForLanguage.certifiedIndependentSmallProducer).asHtml).toString()
+                ).mkString)),
+                actions = Seq(ActionItemViewModel(
+                  href = controllers.sections.items.routes.ItemSmallIndependentProducerController.onPageLoad(testNorthernIrelandErn, testDraftId, testIndex1, CheckMode).url,
                   content = messagesForLanguage.change,
                   id = s"changeItemSmallIndependentProducer${testIndex1.displayIndex}"
                 ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden))
               ))
           }
         }
-        "if false" - {
-          "must return a row" in new Test(
-            emptyUserAnswers
-              .set(ItemSmallIndependentProducerPage(testIndex1), false)
-          ) {
-            ItemSmallIndependentProducerSummary.row(
-              idx = testIndex1
-            ) mustBe
-              Some(summaryListRowBuilder(
-                key = messagesForLanguage.cyaLabel,
-                value = messagesForLanguage.no,
-                changeLink = Some(ActionItemViewModel(
-                  href = controllers.sections.items.routes.ItemSmallIndependentProducerController.onPageLoad(testErn, testDraftId, testIndex1, CheckMode).url,
-                  content = messagesForLanguage.change,
-                  id = s"changeItemSmallIndependentProducer${testIndex1.displayIndex}"
-                ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden))
-              ))
-          }
-        }
+
         "if not provided" - {
           "must not return a row" in new Test(emptyUserAnswers) {
-            ItemSmallIndependentProducerSummary.row(
+            summary.row(
               idx = testIndex1
             ) mustBe None
           }

--- a/test/viewmodels/helpers/ItemCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/helpers/ItemCheckAnswersHelperSpec.scala
@@ -50,6 +50,7 @@ class ItemCheckAnswersHelperSpec extends SpecBase with ItemFixtures with Movemen
     lazy val itemQuantitySummary: ItemQuantitySummary = app.injector.instanceOf[ItemQuantitySummary]
     lazy val itemDegreesPlatoSummary: ItemDegreesPlatoSummary = app.injector.instanceOf[ItemDegreesPlatoSummary]
     lazy val itemDesignationOfOriginSummary: ItemDesignationOfOriginSummary = app.injector.instanceOf[ItemDesignationOfOriginSummary]
+    lazy val itemSmallIndependentProducerSummary: ItemSmallIndependentProducerSummary = app.injector.instanceOf[ItemSmallIndependentProducerSummary]
 
     lazy val helper = new ItemCheckAnswersHelper(
       itemExciseProductCodeSummary = itemExciseProductCodeSummary,
@@ -59,7 +60,8 @@ class ItemCheckAnswersHelperSpec extends SpecBase with ItemFixtures with Movemen
       itemBulkPackagingSealTypeSummary = itemBulkPackagingSealTypeSummary,
       itemQuantitySummary = itemQuantitySummary,
       itemDegreesPlatoSummary = itemDegreesPlatoSummary,
-      itemDesignationOfOriginSummary = itemDesignationOfOriginSummary
+      itemDesignationOfOriginSummary = itemDesignationOfOriginSummary,
+      itemSmallIndependentProducerSummary = itemSmallIndependentProducerSummary
     )
   }
 

--- a/test/viewmodels/helpers/ItemSmallIndependentProducerHelperSpec.scala
+++ b/test/viewmodels/helpers/ItemSmallIndependentProducerHelperSpec.scala
@@ -20,81 +20,210 @@ import base.SpecBase
 import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import forms.sections.items.ItemSmallIndependentProducerFormProvider
+import forms.sections.items.ItemSmallIndependentProducerFormProvider.{producerField, producerIdField}
 import models.GoodsType._
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import models.sections.info.movementScenario.MovementScenario._
+import models.sections.items.ItemSmallIndependentProducerType._
+import pages.sections.info.DestinationTypePage
+import pages.sections.items.{ItemCommodityCodePage, ItemExciseProductCodePage}
 import play.api.i18n.Messages
-import uk.gov.hmrc.govukfrontend.views.Aliases.RadioItem
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
-import viewmodels.LegendSize
-import viewmodels.govuk.all._
+import play.api.test.FakeRequest
+import uk.gov.hmrc.govukfrontend.views.Aliases._
+import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
+import viewmodels.govuk.LabelFluency
 
-class ItemSmallIndependentProducerHelperSpec extends SpecBase with ItemFixtures with GuiceOneAppPerSuite {
+class ItemSmallIndependentProducerHelperSpec extends SpecBase with ItemFixtures with LabelFluency {
+
+  val input: GovukInput = app.injector.instanceOf[GovukInput]
+
+  val helper: ItemSmallIndependentProducerHelper = new ItemSmallIndependentProducerHelper(input)
 
   val form = new ItemSmallIndependentProducerFormProvider()()
 
-  ".radio" - {
+  val messagesForLanguage: ItemSmallIndependentProducerMessages.English.type = ItemSmallIndependentProducerMessages.English
 
-    Seq(ItemSmallIndependentProducerMessages.English).foreach { langMessages =>
+  implicit val messages: Messages = messages(FakeRequest())
 
-      implicit val msgs: Messages = messages(Seq(langMessages.lang))
+  ".radios" - {
 
-      s"when running for language code of '${langMessages.lang.code}'" - {
+    "must return the correct radios" in {
 
-        "should return the expected radio options with correct wording" - {
+      helper.radios(form) mustBe Radios(
+        name = producerField,
+        items = Seq(
+          RadioItem(
+            id = Some(s"${form(producerField).id}-$CertifiedIndependentSmallProducer"),
+            value = Some(CertifiedIndependentSmallProducer.toString),
+            content = Text(messagesForLanguage.certifiedIndependentSmallProducer),
+            hint = Some(Hint(content = Text(messagesForLanguage.certifiedIndependentSmallProducerHint)))
+          ),
+          RadioItem(
+            id = Some(s"${form(producerField).id}-$SelfCertifiedIndependentSmallProducerAndConsignor"),
+            value = Some(SelfCertifiedIndependentSmallProducerAndConsignor.toString),
+            content = Text(messagesForLanguage.selfCertifiedIndependentSmallProducerAndConsignor)
+          ),
+          RadioItem(
+            id = Some(s"${form(producerField).id}-$SelfCertifiedIndependentSmallProducerAndNotConsignor"),
+            value = Some(SelfCertifiedIndependentSmallProducerAndNotConsignor.toString),
+            content = Text(messagesForLanguage.selfCertifiedIndependentSmallProducerNotConsignor),
+            conditionalHtml = Some(
+              input(Input(
+                id = producerIdField,
+                name = producerIdField,
+                label = LabelViewModel(Text(messagesForLanguage.selfCertifiedIndependentSmallProducerNotConsignorInput)),
+                value = form(producerIdField).value
+              ))
+            )
+          ),
+          RadioItem(
+            divider = Some(messagesForLanguage.or)
+          ),
+          RadioItem(
+            id = Some(s"${form(producerField).id}-$NotAIndependentSmallProducer"),
+            value = Some(NotAIndependentSmallProducer.toString),
+            content = Text(messagesForLanguage.notAIndependentSmallProducer)
+          ),
+          RadioItem(
+            id = Some(s"${form(producerField).id}-$NotProvided"),
+            value = Some(NotProvided.toString),
+            content = Text(messagesForLanguage.smallProducerNotProvided)
+          )
+        ), fieldset = Some(Fieldset(legend = Some(Legend(Text(messagesForLanguage.legend), classes = " govuk-fieldset__legend--s")))))
+    }
+  }
 
-          Seq(Beer, Spirits, Wine, Energy, Tobacco, Intermediate).foreach { goodsType =>
+  ".constructDeclarationPrefix" - {
 
-            s"when GoodsType is $goodsType" in {
+    "should return the correct string" - {
 
-              val yesWording = goodsType match {
-                case Beer => langMessages.yesBeer
-                case Spirits => langMessages.yesSpirits
-                case _ => langMessages.yesOther
-              }
+      Seq(GbTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheUk, ExportWithCustomsDeclarationLodgedInTheEu).foreach { movementScenario =>
 
-              ItemSmallIndependentProducerHelper.radios(form, goodsType) mustBe
-                RadiosViewModel.apply(
-                  form("value"),
-                  items = Seq(
-                    RadioItem(
-                      id = Some(form("value").id),
-                      value = Some("true"),
-                      content = Text(langMessages.yesCertified(yesWording))
-                    ),
-                    RadioItem(
-                      id = Some(s"${form("value").id}-no"),
-                      value = Some("false"),
-                      content = Text(langMessages.no)
-                    )
-                  ),
-                  LegendViewModel(Text(langMessages.heading(goodsType.toSingularOutput()))).asPageHeading(LegendSize.Large)
-                )
-            }
-          }
-          s"when GoodsType is ${Fermented(testEpcWine).getClass.getName.stripSuffix("$")}" in {
+        s"for movement scenario: $movementScenario" in {
 
-            val yesWording = langMessages.yesOther
+          implicit val request = dataRequest(FakeRequest(), emptyUserAnswers.set(DestinationTypePage, movementScenario))
 
-            ItemSmallIndependentProducerHelper.radios(form, Fermented(testEpcWine)) mustBe
-              RadiosViewModel.apply(
-                form("value"),
-                items = Seq(
-                  RadioItem(
-                    id = Some(form("value").id),
-                    value = Some("true"),
-                    content = Text(langMessages.yesCertified(yesWording))
-                  ),
-                  RadioItem(
-                    id = Some(s"${form("value").id}-no"),
-                    value = Some("false"),
-                    content = Text(langMessages.no)
-                  )
-                ),
-                LegendViewModel(Text(langMessages.heading(Fermented(testEpcWine).toSingularOutput()))).asPageHeading(LegendSize.Large)
-              )
-          }
+          ItemSmallIndependentProducerHelper.constructDeclarationPrefix(testIndex1) mustBe messagesForLanguage.producedByIndependentSmallProducer
         }
       }
     }
+
+    "should throw an exception" - {
+
+      "when movement scenario is not defined" in {
+
+        implicit val request = dataRequest(FakeRequest(),
+          emptyUserAnswers
+            .set(ItemExciseProductCodePage(testIndex1), testEpcSpirit)
+            .set(ItemCommodityCodePage(testIndex1), testCnCodeSpirit)
+        )
+        intercept[IllegalStateException](ItemSmallIndependentProducerHelper.constructDeclarationPrefix(testIndex1
+        )).getMessage mustBe s"Invalid scenario for small independent producer. Destination type: None & EPC: Some($testEpcSpirit) & CN code: Some($testCnCodeSpirit)"
+      }
+
+      "when EPC is not defined " +
+        "(and movement scenario not GbTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu)" in {
+
+        implicit val request = dataRequest(FakeRequest(),
+          emptyUserAnswers
+            .set(DestinationTypePage, EuTaxWarehouse)
+            .set(ItemCommodityCodePage(testIndex1), testCnCodeSpirit)
+        )
+        intercept[IllegalStateException](ItemSmallIndependentProducerHelper.constructDeclarationPrefix(testIndex1
+        )).getMessage mustBe s"Invalid scenario for small independent producer. Destination type: Some($EuTaxWarehouse) & EPC: None & CN code: Some($testCnCodeSpirit)"
+      }
+
+      "when CN code is not defined " +
+        "(and movement scenario not GbTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu)" in {
+
+        implicit val request = dataRequest(FakeRequest(),
+          emptyUserAnswers
+            .set(DestinationTypePage, EuTaxWarehouse)
+            .set(ItemExciseProductCodePage(testIndex1), testEpcSpirit)
+        )
+        intercept[IllegalStateException](ItemSmallIndependentProducerHelper.constructDeclarationPrefix(testIndex1
+        )).getMessage mustBe s"Invalid scenario for small independent producer. Destination type: Some($EuTaxWarehouse) & EPC: Some($testEpcSpirit) & CN code: None"
+      }
+
+      "when it's not an intra-UK movement or NI -> EU" in {
+
+        implicit val request = dataRequest(FakeRequest(),
+          emptyUserAnswers
+            .set(DestinationTypePage, UnknownDestination)
+            .set(ItemExciseProductCodePage(testIndex1), testEpcSpirit)
+            .set(ItemCommodityCodePage(testIndex1), testCnCodeSpirit)
+        )
+        intercept[IllegalStateException](ItemSmallIndependentProducerHelper.constructDeclarationPrefix(testIndex1
+        )).getMessage mustBe s"Invalid scenario for small independent producer. Destination type: Some($UnknownDestination) & EPC: Some($testEpcSpirit) & CN code: Some($testCnCodeSpirit)"
+      }
+    }
+  }
+
+
+  ".handleNiToEuMovementDeclaration" - {
+
+    "should return the correct string" - {
+
+      Seq(
+        Beer -> messagesForLanguage.producedByIndependentSmallBrewery,
+        Spirits -> messagesForLanguage.producedByIndependentSmallDistillery,
+        Wine -> messagesForLanguage.producedByIndependentWineProducer,
+        Intermediate -> messagesForLanguage.producedByIndependentIntermediateProductsProducer
+      ).foreach { goodsTypeAndExpectedMessage =>
+
+        s"for goods type: ${goodsTypeAndExpectedMessage._1}" in {
+
+          ItemSmallIndependentProducerHelper.handleNiToEuMovementDeclaration(
+            goodsTypeAndExpectedMessage._1.code, testCnCodeWine
+          ) mustBe goodsTypeAndExpectedMessage._2
+        }
+
+      }
+
+      s"for goods type: $Fermented" in {
+
+        ItemSmallIndependentProducerHelper.handleNiToEuMovementDeclaration(
+          testEpcSpirit, testCnCodeSpirit
+        ) mustBe messagesForLanguage.producedByIndependentFermentedBeveragesProducer
+      }
+    }
+
+    "should throw an exception" - {
+
+      Seq(Energy, Tobacco).foreach { goodsType =>
+
+        s"for goods type: $goodsType" in {
+
+          intercept[IllegalStateException](ItemSmallIndependentProducerHelper.handleNiToEuMovementDeclaration(
+            goodsType.code, testCnCodeEnergy
+          )).getMessage mustBe s"Invalid goods type for small independent producer: $goodsType"
+        }
+      }
+    }
+
+  }
+
+  ".isNiToEUMovement" - {
+
+    "should return true" - {
+
+      "when the movement scenario is EU-related and the consignor is an XI trader" in {
+
+        ItemSmallIndependentProducerHelper.isNiToEUMovement(EuTaxWarehouse)(dataRequest(FakeRequest(), ern = testNorthernIrelandErn)) mustBe true
+      }
+    }
+
+    "should return false" - {
+
+      "when the movement scenario is EU-related but the consignor is not an XI trader" in {
+
+        ItemSmallIndependentProducerHelper.isNiToEUMovement(EuTaxWarehouse)(dataRequest(FakeRequest(), ern = testGreatBritainErn)) mustBe false
+      }
+
+      "when the consignor is an XI trader but movement scenario is not EU-related" in {
+
+        ItemSmallIndependentProducerHelper.isNiToEUMovement(GbTaxWarehouse)(dataRequest(FakeRequest(), ern = testNorthernIrelandErn)) mustBe false
+      }
+    }
+
   }
 }

--- a/test/viewmodels/helpers/ItemSmallIndependentProducerHelperSpec.scala
+++ b/test/viewmodels/helpers/ItemSmallIndependentProducerHelperSpec.scala
@@ -96,7 +96,12 @@ class ItemSmallIndependentProducerHelperSpec extends SpecBase with ItemFixtures 
 
     "should return the correct string" - {
 
-      Seq(GbTaxWarehouse, ExportWithCustomsDeclarationLodgedInTheUk, ExportWithCustomsDeclarationLodgedInTheEu).foreach { movementScenario =>
+      Seq(
+        UkTaxWarehouse.GB,
+        UkTaxWarehouse.NI,
+        ExportWithCustomsDeclarationLodgedInTheUk,
+        ExportWithCustomsDeclarationLodgedInTheEu
+      ).foreach { movementScenario =>
 
         s"for movement scenario: $movementScenario" in {
 
@@ -121,7 +126,7 @@ class ItemSmallIndependentProducerHelperSpec extends SpecBase with ItemFixtures 
       }
 
       "when EPC is not defined " +
-        "(and movement scenario not GbTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu)" in {
+        "(and movement scenario not UkTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu)" in {
 
         implicit val request = dataRequest(FakeRequest(),
           emptyUserAnswers
@@ -133,7 +138,7 @@ class ItemSmallIndependentProducerHelperSpec extends SpecBase with ItemFixtures 
       }
 
       "when CN code is not defined " +
-        "(and movement scenario not GbTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu)" in {
+        "(and movement scenario not UkTaxWarehouse | ExportWithCustomsDeclarationLodgedInTheUk | ExportWithCustomsDeclarationLodgedInTheEu)" in {
 
         implicit val request = dataRequest(FakeRequest(),
           emptyUserAnswers
@@ -221,7 +226,7 @@ class ItemSmallIndependentProducerHelperSpec extends SpecBase with ItemFixtures 
 
       "when the consignor is an XI trader but movement scenario is not EU-related" in {
 
-        ItemSmallIndependentProducerHelper.isNiToEUMovement(GbTaxWarehouse)(dataRequest(FakeRequest(), ern = testNorthernIrelandErn)) mustBe false
+        ItemSmallIndependentProducerHelper.isNiToEUMovement(UkTaxWarehouse.GB)(dataRequest(FakeRequest(), ern = testNorthernIrelandErn)) mustBe false
       }
     }
 

--- a/test/views/BaseSelectors.scala
+++ b/test/views/BaseSelectors.scala
@@ -37,6 +37,7 @@ trait BaseSelectors {
   val label: String => String = forId => s"main label[for='$forId']"
   val legend = "main legend"
   def radioButton(radioIndex: Int) = s".govuk-radios > div:nth-child($radioIndex) > label"
+  def radioButtonHint(radioIndex: Int) = s".govuk-radios > div:nth-child($radioIndex) > .govuk-hint"
   def radioDividerButton(radioIndex: Int) = s".govuk-radios > div:nth-child($radioIndex)"
   def checkboxItem(index: Int) = s".govuk-checkboxes > div:nth-child($index) > label"
   def checkboxDividerItem(index: Int) = s".govuk-checkboxes > div:nth-child($index)"

--- a/test/views/sections/consignee/ConsigneeExportInformationViewSpec.scala
+++ b/test/views/sections/consignee/ConsigneeExportInformationViewSpec.scala
@@ -56,7 +56,7 @@ class ConsigneeExportInformationViewSpec extends SpecBase with ViewBehaviours {
           Selectors.subHeadingCaptionSelector -> messagesForLanguage.consigneeInformationSection,
           Selectors.checkboxItem(1) -> messagesForLanguage.checkboxItemForVat,
           Selectors.checkboxItem(2) -> messagesForLanguage.checkboxItemForEori,
-          Selectors.checkboxDividerItem(3) -> messagesForLanguage.checkBoxItemDivider,
+          Selectors.checkboxDividerItem(3) -> messagesForLanguage.or,
           Selectors.checkboxItem(4) -> messagesForLanguage.checkboxItemForNoInfo,
           Selectors.button -> messagesForLanguage.saveAndContinue,
           Selectors.link(1) -> messagesForLanguage.returnToDraft

--- a/test/views/sections/items/ItemSmallIndependentProducerViewSpec.scala
+++ b/test/views/sections/items/ItemSmallIndependentProducerViewSpec.scala
@@ -21,7 +21,7 @@ import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import forms.sections.items.ItemSmallIndependentProducerFormProvider
 import models.requests.DataRequest
-import models.sections.info.movementScenario.MovementScenario.GbTaxWarehouse
+import models.sections.info.movementScenario.MovementScenario.UkTaxWarehouse
 import models.sections.items.ItemSmallIndependentProducerModel
 import models.sections.items.ItemSmallIndependentProducerType.SelfCertifiedIndependentSmallProducerAndNotConsignor
 import org.jsoup.Jsoup
@@ -40,7 +40,7 @@ class ItemSmallIndependentProducerViewSpec extends SpecBase with ViewBehaviours 
 
   implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(),
     emptyUserAnswers
-      .set(DestinationTypePage, GbTaxWarehouse)
+      .set(DestinationTypePage, UkTaxWarehouse.GB)
       .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
       .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
       .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))

--- a/test/views/sections/items/ItemSmallIndependentProducerViewSpec.scala
+++ b/test/views/sections/items/ItemSmallIndependentProducerViewSpec.scala
@@ -17,21 +17,37 @@
 package views.sections.items
 
 import base.SpecBase
+import fixtures.ItemFixtures
 import fixtures.messages.sections.items.ItemSmallIndependentProducerMessages
 import forms.sections.items.ItemSmallIndependentProducerFormProvider
-import models.GoodsType.Beer
 import models.requests.DataRequest
+import models.sections.info.movementScenario.MovementScenario.GbTaxWarehouse
+import models.sections.items.ItemSmallIndependentProducerModel
+import models.sections.items.ItemSmallIndependentProducerType.SelfCertifiedIndependentSmallProducerAndNotConsignor
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import pages.sections.info.DestinationTypePage
+import pages.sections.items.{ItemCommodityCodePage, ItemExciseProductCodePage, ItemSmallIndependentProducerPage}
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import views.html.sections.items.ItemSmallIndependentProducerView
 import views.{BaseSelectors, ViewBehaviours}
 
-class ItemSmallIndependentProducerViewSpec extends SpecBase with ViewBehaviours {
+class ItemSmallIndependentProducerViewSpec extends SpecBase with ViewBehaviours with ItemFixtures {
 
   object Selectors extends BaseSelectors
+
+  implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(),
+    emptyUserAnswers
+      .set(DestinationTypePage, GbTaxWarehouse)
+      .set(ItemExciseProductCodePage(testIndex1), testEpcWine)
+      .set(ItemCommodityCodePage(testIndex1), testCnCodeWine)
+      .set(ItemSmallIndependentProducerPage(testIndex1), ItemSmallIndependentProducerModel(SelfCertifiedIndependentSmallProducerAndNotConsignor, Some(testErn)))
+  )
+
+  lazy val view = app.injector.instanceOf[ItemSmallIndependentProducerView]
+  val form = app.injector.instanceOf[ItemSmallIndependentProducerFormProvider].apply()
 
   "ItemSmallIndependentProducer view" - {
 
@@ -40,19 +56,21 @@ class ItemSmallIndependentProducerViewSpec extends SpecBase with ViewBehaviours 
       s"when being rendered in lang code of '${messagesForLanguage.lang.code}'" - {
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
-        implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest())
 
-       lazy val view = app.injector.instanceOf[ItemSmallIndependentProducerView]
-        val form = app.injector.instanceOf[ItemSmallIndependentProducerFormProvider].apply()
-
-        implicit val doc: Document = Jsoup.parse(view(form, testOnwardRoute, Beer).toString())
+        implicit val doc: Document = Jsoup.parse(view(form, testOnwardRoute, testIndex1).toString())
 
         behave like pageWithExpectedElementsAndMessages(Seq(
-          Selectors.title -> messagesForLanguage.title(Beer.toSingularOutput()),
-          Selectors.h1 -> messagesForLanguage.heading(Beer.toSingularOutput()),
+          Selectors.title -> messagesForLanguage.title,
+          Selectors.h1 -> messagesForLanguage.heading,
           Selectors.subHeadingCaptionSelector -> messagesForLanguage.itemSection,
-          Selectors.radioButton(1) -> messagesForLanguage.yesCertified(messagesForLanguage.yesBeer),
-          Selectors.radioButton(2) -> messagesForLanguage.no,
+          Selectors.radioButton(1) -> messagesForLanguage.certifiedIndependentSmallProducer,
+          Selectors.radioButtonHint(1) -> messagesForLanguage.certifiedIndependentSmallProducerHint,
+          Selectors.radioButton(2) -> messagesForLanguage.selfCertifiedIndependentSmallProducerAndConsignor,
+          Selectors.radioButton(3) -> messagesForLanguage.selfCertifiedIndependentSmallProducerNotConsignor,
+          Selectors.label(ItemSmallIndependentProducerFormProvider.producerIdField) -> messagesForLanguage.selfCertifiedIndependentSmallProducerNotConsignorInput,
+          Selectors.radioDividerButton(5) -> messagesForLanguage.or,
+          Selectors.radioButton(6) -> messagesForLanguage.notAIndependentSmallProducer,
+          Selectors.radioButton(7) -> messagesForLanguage.smallProducerNotProvided,
           Selectors.button -> messagesForLanguage.saveAndContinue,
           Selectors.link(1) -> messagesForLanguage.returnToDraft
         ))

--- a/test/views/sections/items/ItemWineOperationsChoiceViewSpec.scala
+++ b/test/views/sections/items/ItemWineOperationsChoiceViewSpec.scala
@@ -63,7 +63,7 @@ class ItemWineOperationsChoiceViewSpec extends SpecBase with ViewBehaviours with
           Selectors.checkboxItem(10) -> messagesForLanguage.checkBoxItem9,
           Selectors.checkboxItem(11) -> messagesForLanguage.checkBoxItem10,
           Selectors.checkboxItem(12) -> messagesForLanguage.checkBoxItem11,
-          Selectors.checkboxDividerItem(13) -> messagesForLanguage.checkBoxItem12,
+          Selectors.checkboxDividerItem(13) -> messagesForLanguage.or,
           Selectors.checkboxItem(14) -> messagesForLanguage.checkBoxItem13,
           Selectors.button -> messagesForLanguage.saveAndContinue,
           Selectors.link(1) -> messagesForLanguage.returnToDraft

--- a/test/views/sections/transportUnit/TransportUnitAddToListViewSpec.scala
+++ b/test/views/sections/transportUnit/TransportUnitAddToListViewSpec.scala
@@ -62,7 +62,7 @@ class TransportUnitAddToListViewSpec extends SpecBase with ViewBehaviours {
 
         implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
 
-       lazy val view = app.injector.instanceOf[TransportUnitsAddToListView]
+        lazy val view = app.injector.instanceOf[TransportUnitsAddToListView]
         val form = app.injector.instanceOf[TransportUnitsAddToListFormProvider].apply()
         val helper = app.injector.instanceOf[TransportUnitsAddToListHelper].allTransportUnitsSummary()
 
@@ -81,6 +81,7 @@ class TransportUnitAddToListViewSpec extends SpecBase with ViewBehaviours {
           Selectors.legendQuestion -> messagesForLanguage.question,
           Selectors.radioButton(1) -> messagesForLanguage.yesOption,
           Selectors.radioButton(2) -> messagesForLanguage.noOptionSingular,
+          Selectors.radioDividerButton(3) -> messagesForLanguage.or,
           Selectors.radioButton(4) -> messagesForLanguage.laterOption,
           Selectors.button -> messagesForLanguage.saveAndContinue,
           Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
@@ -155,6 +156,7 @@ class TransportUnitAddToListViewSpec extends SpecBase with ViewBehaviours {
           Selectors.errorField -> messagesForLanguage.errorMessageHelper(messagesForLanguage.errorMessage),
           Selectors.radioButton(1) -> messagesForLanguage.yesOption,
           Selectors.radioButton(2) -> messagesForLanguage.noOptionSingular,
+          Selectors.radioDividerButton(3) -> messagesForLanguage.or,
           Selectors.radioButton(4) -> messagesForLanguage.laterOption,
           Selectors.button -> messagesForLanguage.saveAndContinue,
           Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
@@ -201,6 +203,7 @@ class TransportUnitAddToListViewSpec extends SpecBase with ViewBehaviours {
           Selectors.legendQuestion -> messagesForLanguage.question,
           Selectors.radioButton(1) -> messagesForLanguage.yesOption,
           Selectors.radioButton(2) -> messagesForLanguage.noOptionPlural,
+          Selectors.radioDividerButton(3) -> messagesForLanguage.or,
           Selectors.radioButton(4) -> messagesForLanguage.laterOption,
           Selectors.button -> messagesForLanguage.saveAndContinue,
           Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft


### PR DESCRIPTION
Also uncommented logic related to handling unfixed submission failures on the declaration page.

This currently breaks when the destination type is Unknown destination. There is a validation ticket to only allow energy products to be sent when Unknown destination is selected