### PR TITLE
[ETFE-3771] Add postcode validation to Place of Destination and refactor pre-pop from Consignee logic

### DIFF
--- a/app/controllers/sections/destination/DestinationAddressController.scala
+++ b/app/controllers/sections/destination/DestinationAddressController.scala
@@ -24,10 +24,11 @@ import models.requests.DataRequest
 import models.{Mode, UserAddress}
 import navigation.DestinationNavigator
 import pages.QuestionPage
-import pages.sections.destination.DestinationAddressPage
+import pages.sections.consignee.ConsigneeAddressPage
+import pages.sections.destination.{DestinationAddressPage, DestinationConsigneeDetailsPage}
 import play.api.data.Form
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Call, MessagesControllerComponents, Result}
+import play.api.mvc._
 import services.UserAnswersService
 import views.html.AddressView
 
@@ -49,6 +50,15 @@ class DestinationAddressController @Inject()(override val messagesApi: MessagesA
 
   override def onwardCall(mode: Mode)(implicit request: DataRequest[_]): Call =
     controllers.sections.destination.routes.DestinationAddressController.onSubmit(request.ern, request.draftId, mode)
+
+  override def onPageLoad(ern: String, draftId: String, mode: Mode): Action[AnyContent] =
+    authorisedDataRequest(ern, draftId) { implicit request =>
+      val prePopPage = (request.userAnswers.get(addressPage), request.userAnswers.get(DestinationConsigneeDetailsPage)) match {
+        case (None, Some(true)) => ConsigneeAddressPage
+        case _ => addressPage
+      }
+      renderView(Ok, fillForm(prePopPage, formProvider(addressPage)), mode)
+    }
 
   override def renderView(status: Status, form: Form[_], mode: Mode)(implicit request: DataRequest[_]): Result = {
     status(view(

--- a/app/controllers/sections/destination/DestinationBusinessNameController.scala
+++ b/app/controllers/sections/destination/DestinationBusinessNameController.scala
@@ -23,7 +23,8 @@ import models.Mode
 import models.requests.DataRequest
 import models.sections.info.movementScenario.MovementScenario
 import navigation.DestinationNavigator
-import pages.sections.destination.DestinationBusinessNamePage
+import pages.sections.consignee.ConsigneeBusinessNamePage
+import pages.sections.destination.{DestinationBusinessNamePage, DestinationConsigneeDetailsPage}
 import pages.sections.info.DestinationTypePage
 import play.api.data.Form
 import play.api.i18n.MessagesApi
@@ -50,7 +51,11 @@ class DestinationBusinessNameController @Inject()(override val messagesApi: Mess
     authorisedDataRequest(ern, draftId) { implicit request =>
       withAnswer(DestinationTypePage, controllers.sections.destination.routes.DestinationIndexController.onPageLoad(ern, draftId)) {
         destinationType =>
-          renderView(Ok, fillForm(DestinationBusinessNamePage, formProvider()), mode, destinationType)
+          val prePopPage = (request.userAnswers.get(DestinationBusinessNamePage), request.userAnswers.get(DestinationConsigneeDetailsPage)) match {
+            case (None, Some(true)) => ConsigneeBusinessNamePage
+            case _ => DestinationBusinessNamePage
+          }
+          renderView(Ok, fillForm(prePopPage, formProvider()), mode, destinationType)
       }
     }
 

--- a/app/forms/AddressFormProvider.scala
+++ b/app/forms/AddressFormProvider.scala
@@ -22,6 +22,7 @@ import forms.mappings.Mappings
 import models.UserAddress
 import models.requests.DataRequest
 import pages.sections.consignor.ConsignorAddressPage
+import pages.sections.destination.{DestinationAddressPage, DestinationWarehouseExcisePage}
 import pages.sections.dispatch.{DispatchAddressPage, DispatchWarehouseExcisePage}
 import pages.{Page, QuestionPage}
 import play.api.data.Form
@@ -73,6 +74,8 @@ class AddressFormProvider @Inject() extends Mappings {
       case ConsignorAddressPage => niPostcode(request.isNorthernIrelandErn)
       case DispatchAddressPage if request.userAnswers.get(DispatchWarehouseExcisePage).nonEmpty =>
         niPostcode(request.userAnswers.get(DispatchWarehouseExcisePage).exists(_.startsWith(Constants.NI_PREFIX)))
+      case DestinationAddressPage if request.userAnswers.get(DestinationWarehouseExcisePage).nonEmpty =>
+        niPostcode(request.userAnswers.get(DestinationWarehouseExcisePage).exists(_.startsWith(Constants.NI_PREFIX)))
       case _ => Seq.empty
     }
   }

--- a/app/navigation/DestinationNavigator.scala
+++ b/app/navigation/DestinationNavigator.scala
@@ -20,7 +20,7 @@ import controllers.sections.destination.routes
 import models.sections.info.movementScenario.MovementScenario.{CertifiedConsignee, TemporaryCertifiedConsignee}
 import models.{CheckMode, Mode, NormalMode, ReviewMode, UserAnswers}
 import pages.Page
-import pages.sections.consignee.{ConsigneeAddressPage, ConsigneeBusinessNamePage, ConsigneeSection}
+import pages.sections.consignee.{ConsigneeAddressPage, ConsigneeBusinessNamePage}
 import pages.sections.destination._
 import pages.sections.info.DestinationTypePage
 import play.api.mvc.Call

--- a/app/navigation/DestinationNavigator.scala
+++ b/app/navigation/DestinationNavigator.scala
@@ -49,6 +49,12 @@ class DestinationNavigator @Inject() extends BaseNavigator {
   }
 
   private[navigation] val checkRouteMap: Page => UserAnswers => Call = {
+    case DestinationWarehouseExcisePage => (userAnswers: UserAnswers) =>
+      if (userAnswers.get(DestinationAddressPage).isEmpty) {
+        routes.DestinationAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, CheckMode)
+      } else {
+        routes.DestinationCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
+      }
     case _ =>
       (userAnswers: UserAnswers) => routes.DestinationCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
   }

--- a/app/navigation/DestinationNavigator.scala
+++ b/app/navigation/DestinationNavigator.scala
@@ -51,7 +51,7 @@ class DestinationNavigator @Inject() extends BaseNavigator {
   private[navigation] val checkRouteMap: Page => UserAnswers => Call = {
     case DestinationWarehouseExcisePage => (userAnswers: UserAnswers) =>
       if (userAnswers.get(DestinationAddressPage).isEmpty) {
-        routes.DestinationAddressController.onPageLoad(userAnswers.ern, userAnswers.draftId, CheckMode)
+        routes.DestinationBusinessNameController.onPageLoad(userAnswers.ern, userAnswers.draftId, NormalMode)
       } else {
         routes.DestinationCheckAnswersController.onPageLoad(userAnswers.ern, userAnswers.draftId)
       }

--- a/app/pages/sections/destination/DestinationSection.scala
+++ b/app/pages/sections/destination/DestinationSection.scala
@@ -78,15 +78,12 @@ case object DestinationSection extends Section[JsObject] with JsonOptionFormatte
   private def startFlowAtDestinationWarehouseExciseStatus(implicit request: DataRequest[_]): TaskListStatus =
     (
       request.userAnswers.get(DestinationWarehouseExcisePage),
-      request.userAnswers.get(DestinationConsigneeDetailsPage),
       request.userAnswers.get(DestinationBusinessNamePage),
       request.userAnswers.get(DestinationAddressPage)
     ) match {
-      case (Some(_), Some(true), _, _) => Completed
-      case (Some(_), Some(false), Some(_), Some(_)) => Completed
-      case (Some(_), Some(false), bn, a) if bn.isEmpty || a.isEmpty => InProgress
-      case (Some(_), _, _, _) => InProgress
-      case _ => NotStarted
+      case (Some(_), Some(_), Some(_)) => Completed
+      case (None, None, None) => NotStarted
+      case _ => InProgress
     }
 
   private def startFlowAtDestinationWarehouseVatStatus(implicit request: DataRequest[_], destinationTypePageAnswer: MovementScenario): TaskListStatus = {
@@ -97,17 +94,14 @@ case object DestinationSection extends Section[JsObject] with JsonOptionFormatte
 
     (
       destinationDetailsChoice,
-      request.userAnswers.get(DestinationConsigneeDetailsPage),
       request.userAnswers.get(DestinationBusinessNamePage),
       request.userAnswers.get(DestinationAddressPage)
     ) match {
-      case (Some(false), _, _, _) => Completed
-      case (Some(true), Some(true), _, _) => Completed
-      case (Some(true), Some(false), Some(_), Some(_)) => Completed
-      case (Some(_), Some(false), bn, a) if bn.isEmpty || a.isEmpty => InProgress
-      case (Some(_), _, _, _) if !shouldSkipDestinationDetailsChoice => InProgress
+      case (Some(false), _, _) => Completed
+      case (Some(_), Some(_), Some(_)) => Completed
       case _ if request.userAnswers.get(DestinationWarehouseVatPage).nonEmpty => InProgress
-      case _ => NotStarted
+      case (_, None, None) => NotStarted
+      case _ => InProgress
     }
   }
 
@@ -117,7 +111,7 @@ case object DestinationSection extends Section[JsObject] with JsonOptionFormatte
       request.userAnswers.get(DestinationAddressPage)
     ) match {
       case (Some(_), Some(_)) => Completed
-      case (bn, a) if bn.isEmpty && a.isEmpty => NotStarted
+      case (None, None) => NotStarted
       case _ => InProgress
     }
 

--- a/app/viewmodels/checkAnswers/sections/destination/DestinationAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/destination/DestinationAddressSummary.scala
@@ -18,11 +18,10 @@ package viewmodels.checkAnswers.sections.destination
 
 import models.CheckMode
 import models.requests.DataRequest
-import pages.sections.consignee.ConsigneeAddressPage
-import pages.sections.destination.{DestinationAddressPage, DestinationConsigneeDetailsPage}
+import pages.sections.destination.DestinationAddressPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{ActionItem, SummaryListRow, Value}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{SummaryListRow, Value}
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 

--- a/app/viewmodels/checkAnswers/sections/destination/DestinationAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/destination/DestinationAddressSummary.scala
@@ -30,37 +30,20 @@ object DestinationAddressSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): SummaryListRow = {
 
-    val useConsignee = request.userAnswers.get(DestinationConsigneeDetailsPage)
-
-    val businessNamePage = useConsignee match {
-      case Some(true) => ConsigneeAddressPage
-      case _ => DestinationAddressPage
-    }
-
-    val changeAddressLink = Seq(
-      ActionItemViewModel(
-        content = "site.change",
-        href = controllers.sections.destination.routes.DestinationAddressController.onPageLoad(request.ern, request.draftId, CheckMode).url,
-        id = "changeDestinationAddress"
-      ).withVisuallyHiddenText(messages("address.destinationAddress.change.hidden"))
-    )
-
-    val (value, actions) = request.userAnswers.get(businessNamePage).fold[(HtmlContent, Seq[ActionItem])] {
-      useConsignee match {
-        case Some(true) => (HtmlContent(messages("destinationCheckAnswers.consignee.notProvided")), Seq.empty)
-        case _ => (HtmlContent(messages("destinationCheckAnswers.destination.notProvided")), Seq.empty)
-      }
-    } { answer =>
-      useConsignee match {
-        case Some(true) => (answer.toCheckYourAnswersFormat, Seq.empty)
-        case _ => (answer.toCheckYourAnswersFormat, changeAddressLink)
-      }
-    }
+    val value = request.userAnswers.get(DestinationAddressPage).fold[HtmlContent] {
+      HtmlContent(messages("destinationCheckAnswers.destination.notProvided"))
+    } { _.toCheckYourAnswersFormat }
 
     SummaryListRowViewModel(
       key = "address.destinationAddress.checkYourAnswers.label",
       value = Value(value),
-      actions = actions
+      actions = Seq(
+        ActionItemViewModel(
+          content = "site.change",
+          href = controllers.sections.destination.routes.DestinationAddressController.onPageLoad(request.ern, request.draftId, CheckMode).url,
+          id = "changeDestinationAddress"
+        ).withVisuallyHiddenText(messages("address.destinationAddress.change.hidden"))
+      )
     )
   }
 }

--- a/app/viewmodels/checkAnswers/sections/destination/DestinationBusinessNameSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/destination/DestinationBusinessNameSummary.scala
@@ -18,11 +18,10 @@ package viewmodels.checkAnswers.sections.destination
 
 import models.CheckMode
 import models.requests.DataRequest
-import pages.sections.consignee.ConsigneeBusinessNamePage
-import pages.sections.destination.{DestinationBusinessNamePage, DestinationConsigneeDetailsPage}
+import pages.sections.destination.DestinationBusinessNamePage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{ActionItem, SummaryListRow}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
@@ -30,37 +29,18 @@ object DestinationBusinessNameSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): SummaryListRow = {
 
-    val useConsignee = request.userAnswers.get(DestinationConsigneeDetailsPage)
-
-    val businessNamePage = useConsignee match {
-      case Some(true) => ConsigneeBusinessNamePage
-      case _ => DestinationBusinessNamePage
-    }
-
-    val changeBusinessNameLink = Seq(
-      ActionItemViewModel(
-        content = "site.change",
-        href = controllers.sections.destination.routes.DestinationBusinessNameController.onPageLoad(request.ern, request.draftId, CheckMode).url,
-        id = "changeDestinationBusinessName"
-      ).withVisuallyHiddenText(messages("destinationBusinessName.change.hidden"))
-    )
-
-    val (value, actions) = request.userAnswers.get(businessNamePage).fold[(String, Seq[ActionItem])] {
-      useConsignee match {
-        case Some(true) => (messages("destinationCheckAnswers.consignee.notProvided"), Seq.empty)
-        case _ => (messages("destinationCheckAnswers.destination.notProvided"), changeBusinessNameLink)
-      }
-    } { answer =>
-      useConsignee match {
-        case Some(true) => (answer, Seq.empty)
-        case _ => (answer, changeBusinessNameLink)
-      }
-    }
+    val value = request.userAnswers.get(DestinationBusinessNamePage).getOrElse(messages("destinationCheckAnswers.destination.notProvided"))
 
     SummaryListRowViewModel(
       key = "destinationBusinessName.checkYourAnswersLabel",
       value = ValueViewModel(HtmlFormat.escape(value).toString),
-      actions = actions
+      actions = Seq(
+        ActionItemViewModel(
+          content = "site.change",
+          href = controllers.sections.destination.routes.DestinationBusinessNameController.onPageLoad(request.ern, request.draftId, CheckMode).url,
+          id = "changeDestinationBusinessName"
+        ).withVisuallyHiddenText(messages("destinationBusinessName.change.hidden"))
+      )
     )
   }
 }

--- a/test-utils/fixtures/messages/sections/destination/DestinationAddressMessages.scala
+++ b/test-utils/fixtures/messages/sections/destination/DestinationAddressMessages.scala
@@ -25,7 +25,6 @@ object DestinationAddressMessages {
     val cyaLabel: String = "Address"
     val cyaChangeHidden: String = "Address"
     val cyaDestinationNotProvided: String = "Not provided"
-    val cyaConsigneeNotProvided: String = "Consignee section not complete"
   }
 
   object English extends ViewMessages with BaseEnglish

--- a/test/controllers/sections/destination/DestinationAddressControllerSpec.scala
+++ b/test/controllers/sections/destination/DestinationAddressControllerSpec.scala
@@ -24,7 +24,8 @@ import forms.AddressFormProvider
 import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAddress, UserAnswers}
 import navigation.FakeNavigators.FakeDestinationNavigator
-import pages.sections.destination.DestinationAddressPage
+import pages.sections.consignee.ConsigneeAddressPage
+import pages.sections.destination.{DestinationAddressPage, DestinationConsigneeDetailsPage}
 import play.api.data.Form
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -76,6 +77,38 @@ class DestinationAddressControllerSpec extends SpecBase with MockUserAnswersServ
       )(dataRequest(request), messages(request)).toString
     }
 
+    "must fill the form with data from ConisgnorAddress when UseConsignee is true and no Destination address exists" in new Fixture(Some(
+      emptyUserAnswers
+        .set(DestinationConsigneeDetailsPage, true)
+        .set(ConsigneeAddressPage, testUserAddress.copy(street = "Consignee"))
+    )) {
+      val result = testController.onPageLoad(testErn, testDraftId, NormalMode)(request)
+
+      status(result) mustEqual OK
+      contentAsString(result) mustEqual view(
+        form = form.fill(testUserAddress.copy(street = "Consignee")),
+        addressPage = DestinationAddressPage,
+        call = destinationAddressOnSubmit,
+        headingKey = Some("destinationAddress")
+      )(dataRequest(request), messages(request)).toString
+    }
+
+    "must fill the form with data from DestinationAddress when UseConsignee is true and Destination address exists" in new Fixture(Some(
+      emptyUserAnswers
+        .set(DestinationConsigneeDetailsPage, true)
+        .set(ConsigneeAddressPage, testUserAddress.copy(street = "Consignee"))
+        .set(DestinationAddressPage, testUserAddress.copy(street = "Destination"))
+    )) {
+      val result = testController.onPageLoad(testErn, testDraftId, NormalMode)(request)
+
+      status(result) mustEqual OK
+      contentAsString(result) mustEqual view(
+        form = form.fill(testUserAddress.copy(street = "Destination")),
+        addressPage = DestinationAddressPage,
+        call = destinationAddressOnSubmit,
+        headingKey = Some("destinationAddress")
+      )(dataRequest(request), messages(request)).toString
+    }
 
     "must redirect to the next page when valid data is submitted" in new Fixture() {
 

--- a/test/controllers/sections/destination/DestinationAddressControllerSpec.scala
+++ b/test/controllers/sections/destination/DestinationAddressControllerSpec.scala
@@ -77,7 +77,7 @@ class DestinationAddressControllerSpec extends SpecBase with MockUserAnswersServ
       )(dataRequest(request), messages(request)).toString
     }
 
-    "must fill the form with data from ConisgnorAddress when UseConsignee is true and no Destination address exists" in new Fixture(Some(
+    "must fill the form with data from ConsignorAddress when UseConsignee is true and no Destination address exists" in new Fixture(Some(
       emptyUserAnswers
         .set(DestinationConsigneeDetailsPage, true)
         .set(ConsigneeAddressPage, testUserAddress.copy(street = "Consignee"))

--- a/test/forms/AddressFormProviderSpec.scala
+++ b/test/forms/AddressFormProviderSpec.scala
@@ -22,6 +22,7 @@ import forms.behaviours.FieldBehaviours
 import models.UserAddress
 import models.requests.DataRequest
 import pages.sections.consignor.ConsignorAddressPage
+import pages.sections.destination.{DestinationAddressPage, DestinationWarehouseExcisePage}
 import pages.sections.dispatch.{DispatchAddressPage, DispatchWarehouseExcisePage}
 import play.api.data.FormError
 import play.api.mvc.AnyContentAsEmpty
@@ -279,6 +280,54 @@ class AddressFormProviderSpec extends SpecBase with FieldBehaviours with UserAdd
     "where the DispatchWarehouseERN is not known" - {
 
       lazy val unknownErnForm = new AddressFormProvider()(DispatchAddressPage)(dataRequest(FakeRequest(), emptyUserAnswers))
+
+      "must bind Non-BT postcode" in {
+        unknownErnForm.bind(formAnswersMap(Some(postcodeField), Some("B1 1AA"))).errors mustBe empty
+      }
+
+      "must bind BT postcode" in {
+        unknownErnForm.bind(formAnswersMap(Some(postcodeField), Some("BT1 1AA"))).errors mustBe empty
+      }
+    }
+  }
+
+  "for the DestinationAddress Page" - {
+
+    "for a GB ERN" - {
+
+      lazy val gbForm = new AddressFormProvider()(DestinationAddressPage)(dataRequest(FakeRequest(),
+        emptyUserAnswers.set(DestinationWarehouseExcisePage, testGreatBritainErn)
+      ))
+
+      "must not bind for 'BT' postcode" in {
+        val expectedResult = Seq(FormError(postcodeField, notBTPostcodeKey, Seq()))
+        gbForm.bind(formAnswersMap(Some(postcodeField), Some("BT1 1AA"))).errors mustBe expectedResult
+      }
+
+      "must bind for postcode not beginning with 'BT'" in {
+        gbForm.bind(formAnswersMap(Some(postcodeField), Some("B1 1AA"))).errors mustBe empty
+      }
+    }
+
+    "for an XI ERN" - {
+
+      lazy val xiForm = new AddressFormProvider()(DestinationAddressPage)(dataRequest(FakeRequest(),
+        emptyUserAnswers.set(DestinationWarehouseExcisePage, testNorthernIrelandErn)
+      ))
+
+      "must not bind for non-BT postcode" in {
+        val expectedResult = Seq(FormError(postcodeField, mustBeBTPostcodeKey, Seq()))
+        xiForm.bind(formAnswersMap(Some(postcodeField), Some("B1 1AA"))).errors mustBe expectedResult
+      }
+
+      "must bind for postcode beginning with 'BT'" in {
+        xiForm.bind(formAnswersMap(Some(postcodeField), Some("BT1 1AA"))).errors mustBe empty
+      }
+    }
+
+    "where the DispatchWarehouseERN is not known" - {
+
+      lazy val unknownErnForm = new AddressFormProvider()(DestinationAddressPage)(dataRequest(FakeRequest(), emptyUserAnswers))
 
       "must bind Non-BT postcode" in {
         unknownErnForm.bind(formAnswersMap(Some(postcodeField), Some("B1 1AA"))).errors mustBe empty

--- a/test/models/submitCreateMovement/TraderModelSpec.scala
+++ b/test/models/submitCreateMovement/TraderModelSpec.scala
@@ -267,28 +267,6 @@ class TraderModelSpec extends SpecBase {
   "applyDeliveryPlace" - {
     "must return a TraderModel" - {
       "when DestinationTypePage means shouldStartFlowAtDestinationWarehouseExcise" - {
-        "when useConsigneeDetails = true" in {
-          Seq(UkTaxWarehouse.GB, UkTaxWarehouse.NI, EuTaxWarehouse).foreach {
-            movementScenario =>
-              implicit val dr: DataRequest[_] = dataRequest(
-                fakeRequest,
-                emptyUserAnswers
-                  .set(DestinationTypePage, movementScenario)
-                  .set(DestinationWarehouseExcisePage, "destination ern")
-                  .set(DestinationConsigneeDetailsPage, true)
-                  .set(DestinationBusinessNamePage, "destination name")
-                  .set(DestinationAddressPage, testUserAddress.copy(street = "destination street"))
-                  .set(ConsigneeBusinessNamePage, "consignee name")
-                  .set(ConsigneeExcisePage, "consignee ern")
-                  .set(ConsigneeExportEoriPage, "consignee eori")
-                  .set(ConsigneeAddressPage, testUserAddress.copy(street = "consignee street"))
-              )
-
-              TraderModel.applyDeliveryPlace(movementScenario) mustBe
-                Some(consigneeTraderWithErn.copy(traderExciseNumber = Some("destination ern"), eoriNumber = None))
-          }
-        }
-        "when useConsigneeDetails = false" in {
           Seq(UkTaxWarehouse.GB, UkTaxWarehouse.NI, EuTaxWarehouse).foreach {
             movementScenario =>
               implicit val dr: DataRequest[_] = dataRequest(
@@ -304,29 +282,8 @@ class TraderModelSpec extends SpecBase {
               TraderModel.applyDeliveryPlace(movementScenario) mustBe Some(deliveryPlaceTrader)
           }
         }
-      }
       "when DestinationTypePage means shouldStartFlowAtDestinationWarehouseVat" - {
-        "when giveAddressAndBusinessName = true, and use consignee address = true" in {
-          Seq(RegisteredConsignee, TemporaryRegisteredConsignee, ExemptedOrganisation).foreach {
-            movementScenario =>
-              implicit val dr: DataRequest[_] = dataRequest(
-                fakeRequest,
-                emptyUserAnswers
-                  .set(ConsigneeBusinessNamePage, "consignee name")
-                  .set(ConsigneeAddressPage, testUserAddress.copy(street = "consignee street"))
-                  .set(DestinationTypePage, movementScenario)
-                  .set(DestinationWarehouseVatPage, "destination ern")
-                  .set(DestinationDetailsChoicePage, true)
-                  .set(DestinationConsigneeDetailsPage, true)
-                  .set(DestinationBusinessNamePage, "destination name")
-                  .set(DestinationAddressPage, testUserAddress.copy(street = "destination street"))
-              )
-
-              TraderModel.applyDeliveryPlace(movementScenario) mustBe
-                Some(consigneeTraderWithNeitherErnNorVatNo.copy(traderExciseNumber = Some("destination ern")))
-          }
-        }
-        "when giveAddressAndBusinessName = true, and use consignee address = false" in {
+        "when giveAddressAndBusinessName = true" in {
           Seq(RegisteredConsignee, TemporaryRegisteredConsignee, ExemptedOrganisation).foreach {
             movementScenario =>
               implicit val dr: DataRequest[_] = dataRequest(
@@ -360,8 +317,6 @@ class TraderModelSpec extends SpecBase {
               TraderModel.applyDeliveryPlace(movementScenario) mustBe Some(deliveryPlaceTrader.copy(traderName = None, address = None))
           }
         }
-      }
-      "when DestinationTypePage means shouldStartFlowAtDestinationWarehouseVat" - {
         "and shouldSkipDestinationDetailsChoice" in {
           Seq(CertifiedConsignee, TemporaryCertifiedConsignee).foreach {
             movementScenario =>

--- a/test/navigation/DestinationNavigatorSpec.scala
+++ b/test/navigation/DestinationNavigatorSpec.scala
@@ -182,6 +182,29 @@ class DestinationNavigatorSpec extends SpecBase {
 
     "in Check mode" - {
 
+      "for the DestinationWarehouseExcisePage" - {
+
+        "if there is no DispatchAddress (because value for ERN was changed from GB-->XI or XI-->GB" - {
+
+          "must go to the DestinationAddress page" in {
+
+            navigator.nextPage(DestinationWarehouseExcisePage, CheckMode, emptyUserAnswers) mustBe
+              routes.DestinationAddressController.onPageLoad(testErn, testDraftId, CheckMode)
+          }
+        }
+
+        "if there is a DispatchAddress" - {
+
+          "must go to the DestinationCheckAnswers page" in {
+
+            val userAnswers = emptyUserAnswers.set(DestinationAddressPage, testUserAddress)
+
+            navigator.nextPage(DestinationWarehouseExcisePage, CheckMode, userAnswers) mustBe
+              routes.DestinationCheckAnswersController.onPageLoad(testErn, testDraftId)
+          }
+        }
+      }
+
       "must go to CheckYourAnswersDestinationController" in {
 
         case object UnknownPage extends Page

--- a/test/navigation/DestinationNavigatorSpec.scala
+++ b/test/navigation/DestinationNavigatorSpec.scala
@@ -186,10 +186,10 @@ class DestinationNavigatorSpec extends SpecBase {
 
         "if there is no DispatchAddress (because value for ERN was changed from GB-->XI or XI-->GB" - {
 
-          "must go to the DestinationAddress page" in {
+          "must go to the DestinationBusinessName page in Normal mode to traverse back through and re-confirm" in {
 
             navigator.nextPage(DestinationWarehouseExcisePage, CheckMode, emptyUserAnswers) mustBe
-              routes.DestinationAddressController.onPageLoad(testErn, testDraftId, CheckMode)
+              routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
           }
         }
 

--- a/test/navigation/DestinationNavigatorSpec.scala
+++ b/test/navigation/DestinationNavigatorSpec.scala
@@ -21,6 +21,7 @@ import controllers.sections.destination.routes
 import models.sections.info.movementScenario.MovementScenario.{CertifiedConsignee, TemporaryCertifiedConsignee}
 import models.{CheckMode, NormalMode, ReviewMode}
 import pages.Page
+import pages.sections.consignee.{ConsigneeAddressPage, ConsigneeBusinessNamePage}
 import pages.sections.destination._
 import pages.sections.info.DestinationTypePage
 
@@ -40,29 +41,57 @@ class DestinationNavigatorSpec extends SpecBase {
 
       "for the DestinationWarehouseExcisePage" - {
 
-        "must go to Destination Consignee details page" in {
+        "when ConsigneeDetails exist" - {
 
-          navigator.nextPage(DestinationWarehouseExcisePage, NormalMode, emptyUserAnswers) mustBe
-            routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+          "must go to Destination Consignee details page" in {
+
+            val userAnswers = emptyUserAnswers
+              .set(ConsigneeAddressPage, testUserAddress)
+              .set(ConsigneeBusinessNamePage, testBusinessName)
+
+            navigator.nextPage(DestinationWarehouseExcisePage, NormalMode, userAnswers) mustBe
+              routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+          }
+        }
+
+        "when ConsigneeDetails DO NOT exist" - {
+
+          "must go to Destination Business Name page" in {
+
+            navigator.nextPage(DestinationWarehouseExcisePage, NormalMode, emptyUserAnswers) mustBe
+              routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
+          }
         }
       }
 
       "for the DestinationWarehouseVatPage" - {
 
-        "must go to DestinationDetailsChoice page when DestinationType is CertifiedConsignee" in {
+        Seq(CertifiedConsignee, TemporaryCertifiedConsignee).foreach { destinationType =>
 
-          val userAnswers = emptyUserAnswers.set(DestinationTypePage, CertifiedConsignee)
+          "when Consignee Details exist" - {
 
-          navigator.nextPage(DestinationWarehouseVatPage, NormalMode, userAnswers) mustBe
-            routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
-        }
+            s"must go to DestinationConsigneeDetails page when DestinationType is $destinationType" in {
 
-        "must go to DestinationDetailsChoice page when DestinationType is TemporaryCertifiedConsignee" in {
+              val userAnswers = emptyUserAnswers
+                .set(ConsigneeAddressPage, testUserAddress)
+                .set(ConsigneeBusinessNamePage, testBusinessName)
+                .set(DestinationTypePage, destinationType)
 
-          val userAnswers = emptyUserAnswers.set(DestinationTypePage, TemporaryCertifiedConsignee)
+              navigator.nextPage(DestinationWarehouseVatPage, NormalMode, userAnswers) mustBe
+                routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+            }
+          }
 
-          navigator.nextPage(DestinationWarehouseVatPage, NormalMode, userAnswers) mustBe
-            routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+          "when Consignee Details DO NOT exist" - {
+
+            s"must go to DestinationBusinessName page when DestinationType is $destinationType" in {
+
+              val userAnswers = emptyUserAnswers.set(DestinationTypePage, destinationType)
+
+              navigator.nextPage(DestinationWarehouseVatPage, NormalMode, userAnswers) mustBe
+                routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
+            }
+          }
         }
 
         "must go to DestinationDetailsChoice page when DestinationType is NOT CertifiedConsignee or TemporaryCertifiedConsignee" in {
@@ -74,12 +103,29 @@ class DestinationNavigatorSpec extends SpecBase {
 
       "for the DestinationDetailsChoicePage" - {
 
-        "must go to CAM-DES03 when user selects yes" in {
+        "when ConsigneeDetails exist" - {
 
-          val userAnswers = emptyUserAnswers.set(DestinationDetailsChoicePage, true)
+          "must go to DestinationConsigneeDetails (CAM-DES03) when user selects yes" in {
 
-          navigator.nextPage(DestinationDetailsChoicePage, NormalMode, userAnswers) mustBe
-            routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+            val userAnswers = emptyUserAnswers
+              .set(ConsigneeBusinessNamePage, testBusinessName)
+              .set(ConsigneeAddressPage, testUserAddress)
+              .set(DestinationDetailsChoicePage, true)
+
+            navigator.nextPage(DestinationDetailsChoicePage, NormalMode, userAnswers) mustBe
+              routes.DestinationConsigneeDetailsController.onPageLoad(testErn, testDraftId, NormalMode)
+          }
+        }
+
+        "when ConsigneeDetails DO NOT exist" - {
+
+          "must go to DestinationBusinessName when user selects yes" in {
+
+            val userAnswers = emptyUserAnswers.set(DestinationDetailsChoicePage, true)
+
+            navigator.nextPage(DestinationDetailsChoicePage, NormalMode, userAnswers) mustBe
+              routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
+          }
         }
 
         "must go to DestinationCheckAnswersPage when user selects no" in {
@@ -99,27 +145,10 @@ class DestinationNavigatorSpec extends SpecBase {
 
       "for the DestinationConsigneeDetailsPage" - {
 
-        "must go to Destination Business Name page (CAM-DES04) if answer is no" in {
-
-          val userAnswers = emptyUserAnswers.set(DestinationConsigneeDetailsPage, false)
-
-          navigator.nextPage(DestinationConsigneeDetailsPage, NormalMode, userAnswers) mustBe
-            routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
-
-        }
-
-        "must go to Destination Check Answers page (CAM-DES06) if answer is yes" in {
-
-          val userAnswers = emptyUserAnswers.set(DestinationConsigneeDetailsPage, true)
-
-          navigator.nextPage(DestinationConsigneeDetailsPage, NormalMode, userAnswers) mustBe
-            routes.DestinationCheckAnswersController.onPageLoad(testErn, testDraftId)
-        }
-
-        "must go to Journey Recovery Controller if no answer is present" in {
+        "must go to Destination Business Name page (CAM-DES04)" in {
 
           navigator.nextPage(DestinationConsigneeDetailsPage, NormalMode, emptyUserAnswers) mustBe
-            controllers.routes.JourneyRecoveryController.onPageLoad()
+            routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, NormalMode)
         }
       }
 

--- a/test/pages/sections/destination/DestinationSectionSpec.scala
+++ b/test/pages/sections/destination/DestinationSectionSpec.scala
@@ -21,7 +21,6 @@ import fixtures.{MovementSubmissionFailureFixtures, UserAddressFixtures}
 import models.requests.DataRequest
 import models.sections.info.movementScenario.MovementScenario
 import models.sections.info.movementScenario.MovementScenario._
-import pages.QuestionPage
 import pages.sections.info.DestinationTypePage
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -52,7 +51,7 @@ class DestinationSectionSpec extends SpecBase
 
     "when shouldStartFlowAtDestinationWarehouseExcise" - {
       "must return Completed" - {
-        "when mandatory pages have an answer and DestinationConsigneeDetailsPage = true" in {
+        "when mandatory pages have an answer" in {
           Seq(
             UkTaxWarehouse.GB,
             UkTaxWarehouse.NI,
@@ -66,31 +65,8 @@ class DestinationSectionSpec extends SpecBase
 
               implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
                 .set(DestinationTypePage, destinationTypePageAnswer)
-                .set(DestinationWarehouseExcisePage, "")
-                .set(DestinationConsigneeDetailsPage, true)
-              )
-
-              DestinationSection.status mustBe Completed
-          }
-        }
-
-        "when mandatory pages have an answer and DestinationConsigneeDetailsPage = false" in {
-          Seq(
-            UkTaxWarehouse.GB,
-            UkTaxWarehouse.NI,
-            EuTaxWarehouse
-          ).foreach {
-            implicit destinationTypePageAnswer =>
-              assert(
-                DestinationSection.shouldStartFlowAtDestinationWarehouseExcise === true,
-                s"shouldStartFlowAtDestinationWarehouseExcise returned false for MovementScenario $destinationTypePageAnswer"
-              )
-
-              implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
-                .set(DestinationTypePage, destinationTypePageAnswer)
-                .set(DestinationWarehouseExcisePage, "")
-                .set(DestinationConsigneeDetailsPage, false)
-                .set(DestinationBusinessNamePage, "")
+                .set(DestinationWarehouseExcisePage, testErn)
+                .set(DestinationBusinessNamePage, testBusinessName)
                 .set(DestinationAddressPage, testUserAddress)
               )
 
@@ -100,7 +76,7 @@ class DestinationSectionSpec extends SpecBase
       }
 
       "must return InProgress" - {
-        "when some, but not all, mandatory pages have an answer and DestinationConsigneeDetailsPage = true" in {
+        "when some, but not all, mandatory pages have an answer" in {
           Seq(
             UkTaxWarehouse.GB,
             UkTaxWarehouse.NI,
@@ -114,45 +90,12 @@ class DestinationSectionSpec extends SpecBase
 
               val baseUserAnswers = emptyUserAnswers
                 .set(DestinationTypePage, destinationTypePageAnswer)
-                .set(DestinationWarehouseExcisePage, "")
-                .set(DestinationConsigneeDetailsPage, true)
-
-              Seq(
-                DestinationConsigneeDetailsPage,
-              ).foreach {
-                page =>
-                  implicit val dr: DataRequest[_] = dataRequest(request, baseUserAnswers
-                    .remove(page)
-                  )
-
-                  DestinationSection.status mustBe InProgress
-              }
-          }
-        }
-
-        "when some, but not all, mandatory pages have an answer and DestinationConsigneeDetailsPage = false" in {
-          Seq(
-            UkTaxWarehouse.GB,
-            UkTaxWarehouse.NI,
-            EuTaxWarehouse
-          ).foreach {
-            implicit destinationTypePageAnswer =>
-              assert(
-                DestinationSection.shouldStartFlowAtDestinationWarehouseExcise === true,
-                s"shouldStartFlowAtDestinationWarehouseExcise returned false for MovementScenario $destinationTypePageAnswer"
-              )
-
-              val baseUserAnswers = emptyUserAnswers
-                .set(DestinationTypePage, destinationTypePageAnswer)
-                .set(DestinationWarehouseExcisePage, "")
-                .set(DestinationConsigneeDetailsPage, false)
-                .set(DestinationBusinessNamePage, "")
+                .set(DestinationWarehouseExcisePage, testErn)
+                .set(DestinationBusinessNamePage, testBusinessName)
                 .set(DestinationAddressPage, testUserAddress)
 
-              Seq[QuestionPage[Any]](
-                DestinationConsigneeDetailsPage,
-                DestinationBusinessNamePage,
-                DestinationAddressPage
+              Seq(
+                DestinationAddressPage, DestinationBusinessNamePage, DestinationWarehouseExcisePage
               ).foreach {
                 page =>
                   implicit val dr: DataRequest[_] = dataRequest(request, baseUserAnswers
@@ -194,7 +137,7 @@ class DestinationSectionSpec extends SpecBase
 
         "must return Completed" - {
 
-          "when mandatory pages have an answer, DestinationDetailsChoicePage = true and DestinationConsigneeDetailsPage = true" in {
+          "when mandatory pages have an answer and DestinationDetailsChoicePage = true" in {
             Seq(
               RegisteredConsignee,
               TemporaryRegisteredConsignee,
@@ -209,31 +152,8 @@ class DestinationSectionSpec extends SpecBase
                 implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
                   .set(DestinationTypePage, destinationTypePageAnswer)
                   .set(DestinationDetailsChoicePage, true)
-                  .set(DestinationConsigneeDetailsPage, true)
-                )
-
-                DestinationSection.status mustBe Completed
-            }
-          }
-
-          "when mandatory pages have an answer, DestinationDetailsChoicePage = true and DestinationConsigneeDetailsPage = false" in {
-            Seq(
-              RegisteredConsignee,
-              TemporaryRegisteredConsignee,
-              ExemptedOrganisation
-            ).foreach {
-              implicit destinationTypePageAnswer =>
-                assert(
-                  DestinationSection.shouldStartFlowAtDestinationWarehouseVat === true,
-                  s"shouldStartFlowAtDestinationWarehouseVat returned false for MovementScenario $destinationTypePageAnswer"
-                )
-
-                implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
-                  .set(DestinationTypePage, destinationTypePageAnswer)
-                  .set(DestinationDetailsChoicePage, true)
-                  .set(DestinationConsigneeDetailsPage, false)
-                  .set(DestinationBusinessNamePage, "")
                   .set(DestinationAddressPage, testUserAddress)
+                  .set(DestinationBusinessNamePage, testBusinessName)
                 )
 
                 DestinationSection.status mustBe Completed
@@ -263,7 +183,7 @@ class DestinationSectionSpec extends SpecBase
         }
 
         "must return InProgress" - {
-          "when some, but not all, mandatory pages have an answer, DestinationDetailsChoicePage = true, DestinationConsigneeDetailsPage = false" in {
+          "when some, but not all, mandatory pages have an answer and DestinationDetailsChoicePage = true" in {
             Seq(
               RegisteredConsignee,
               TemporaryRegisteredConsignee,
@@ -278,8 +198,7 @@ class DestinationSectionSpec extends SpecBase
                 val baseUserAnswers = emptyUserAnswers
                   .set(DestinationTypePage, destinationTypePageAnswer)
                   .set(DestinationDetailsChoicePage, true)
-                  .set(DestinationConsigneeDetailsPage, false)
-                  .set(DestinationBusinessNamePage, "")
+                  .set(DestinationBusinessNamePage, testBusinessName)
                   .set(DestinationAddressPage, testUserAddress)
 
                 Seq(DestinationBusinessNamePage, DestinationAddressPage).foreach {
@@ -291,47 +210,6 @@ class DestinationSectionSpec extends SpecBase
                     DestinationSection.status mustBe InProgress
                 }
 
-            }
-          }
-
-          "when some, but not all, mandatory pages have an answer, DestinationDetailsChoicePage = true, DestinationConsigneeDetailsPage = missing" in {
-            Seq(
-              RegisteredConsignee,
-              TemporaryRegisteredConsignee,
-              ExemptedOrganisation
-            ).foreach {
-              implicit destinationTypePageAnswer =>
-                assert(
-                  DestinationSection.shouldStartFlowAtDestinationWarehouseVat === true,
-                  s"shouldStartFlowAtDestinationWarehouseVat returned false for MovementScenario $destinationTypePageAnswer"
-                )
-                implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
-                  .set(DestinationTypePage, destinationTypePageAnswer)
-                  .set(DestinationDetailsChoicePage, true)
-                )
-
-                DestinationSection.status mustBe InProgress
-            }
-
-          }
-
-          "when mandatory pages are missing but DestinationWarehouseVatPage has an answer" in {
-            Seq(
-              RegisteredConsignee,
-              TemporaryRegisteredConsignee,
-              ExemptedOrganisation
-            ).foreach {
-              implicit destinationTypePageAnswer =>
-                assert(
-                  DestinationSection.shouldStartFlowAtDestinationWarehouseVat === true,
-                  s"shouldStartFlowAtDestinationWarehouseVat returned false for MovementScenario $destinationTypePageAnswer"
-                )
-                implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
-                  .set(DestinationTypePage, destinationTypePageAnswer)
-                  .set(DestinationWarehouseVatPage, "")
-                )
-
-                DestinationSection.status mustBe InProgress
             }
           }
         }
@@ -363,26 +241,6 @@ class DestinationSectionSpec extends SpecBase
 
         "must return Completed" - {
 
-          "when mandatory pages have an answer DestinationConsigneeDetailsPage = true" in {
-            Seq(
-              CertifiedConsignee,
-              TemporaryCertifiedConsignee
-            ).foreach {
-              implicit destinationTypePageAnswer =>
-                assert(
-                  DestinationSection.shouldStartFlowAtDestinationWarehouseVat === true,
-                  s"shouldStartFlowAtDestinationWarehouseVat returned false for MovementScenario $destinationTypePageAnswer"
-                )
-
-                implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
-                  .set(DestinationTypePage, destinationTypePageAnswer)
-                  .set(DestinationConsigneeDetailsPage, true)
-                )
-
-                DestinationSection.status mustBe Completed
-            }
-          }
-
           "when mandatory pages have an answer DestinationConsigneeDetailsPage = false" in {
             Seq(
               CertifiedConsignee,
@@ -396,8 +254,7 @@ class DestinationSectionSpec extends SpecBase
 
                 implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
                   .set(DestinationTypePage, destinationTypePageAnswer)
-                  .set(DestinationConsigneeDetailsPage, false)
-                  .set(DestinationBusinessNamePage, "")
+                  .set(DestinationBusinessNamePage, testErn)
                   .set(DestinationAddressPage, testUserAddress)
                 )
 
@@ -449,7 +306,7 @@ class DestinationSectionSpec extends SpecBase
                 )
                 implicit val dr: DataRequest[_] = dataRequest(request, emptyUserAnswers
                   .set(DestinationTypePage, destinationTypePageAnswer)
-                  .set(DestinationWarehouseVatPage, "")
+                  .set(DestinationWarehouseVatPage, testVatNumber)
                 )
 
                 DestinationSection.status mustBe InProgress

--- a/test/viewmodels/checkAnswers/sections/destination/DestinationAddressSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/destination/DestinationAddressSummarySpec.scala
@@ -21,120 +21,60 @@ import fixtures.UserAddressFixtures
 import fixtures.messages.sections.destination.DestinationAddressMessages
 import models.CheckMode
 import org.scalatest.matchers.must.Matchers
-import pages.sections.consignee.ConsigneeAddressPage
 import pages.sections.destination.{DestinationAddressPage, DestinationConsigneeDetailsPage}
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
-import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+import uk.gov.hmrc.govukfrontend.views.Aliases.{Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
 import viewmodels.govuk.summarylist._
-import viewmodels.implicits._
 
 class DestinationAddressSummarySpec extends SpecBase with Matchers with UserAddressFixtures {
 
   "DestinationAddressSummary" - {
 
-    Seq(DestinationAddressMessages.English).foreach { messagesForLanguage =>
+    Seq(DestinationAddressMessages.English).foreach { implicit messagesForLanguage =>
 
       s"when being rendered in lang code of '${messagesForLanguage.lang.code}'" - {
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        "when there's no answer" - {
+        "when Destination Address has NOT been answered" - {
 
-          "must output no row" in {
+          "must output a Not Provided row" in {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
-            DestinationAddressSummary.row() mustBe SummaryListRowViewModel(
-              key = messagesForLanguage.cyaLabel,
-              value = Value(HtmlContent(messagesForLanguage.cyaDestinationNotProvided)),
-              actions = Seq.empty
+            DestinationAddressSummary.row() mustBe expectedSummary(Value(HtmlContent(messagesForLanguage.cyaDestinationNotProvided)))
+          }
+        }
+
+        "when Destination Address has been answered" - {
+
+          "must output the expected row" in {
+
+            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
+              .set(DestinationConsigneeDetailsPage, false)
+              .set(DestinationAddressPage, userAddressModelMax)
             )
 
-          }
-        }
-
-        "when the DestinationConsigneeDetailsPage has been answered no" - {
-
-          "when there is no Destination Address given" - {
-
-            s"must output ${messagesForLanguage.cyaDestinationNotProvided}" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, false)
-              )
-
-              DestinationAddressSummary.row() mustBe SummaryListRowViewModel(
-                key = messagesForLanguage.cyaLabel,
-                value = Value(HtmlContent(messagesForLanguage.cyaDestinationNotProvided)),
-                actions = Seq.empty
-              )
-            }
-          }
-
-          "when Destination Address has been answered" - {
-
-            "must output the expected row" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, false)
-                .set(DestinationAddressPage, userAddressModelMax)
-              )
-
-              DestinationAddressSummary.row() mustBe
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(userAddressModelMax.toCheckYourAnswersFormat),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = controllers.sections.destination.routes.DestinationAddressController.onPageLoad(testErn, testDraftId, CheckMode).url,
-                      id = "changeDestinationAddress"
-                    ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
-                  )
-                )
-            }
-          }
-        }
-
-        "when the DestinationConsigneeDetailsPage has been answered yes" - {
-
-          "when there is no Consignee Address given" - {
-
-            s"must output ${messagesForLanguage.cyaConsigneeNotProvided}" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, true)
-              )
-
-              DestinationAddressSummary.row() mustBe SummaryListRowViewModel(
-                key = messagesForLanguage.cyaLabel,
-                value = Value(HtmlContent(messagesForLanguage.cyaConsigneeNotProvided)),
-                actions = Seq.empty
-              )
-            }
-          }
-
-          "when Consignee Address has been answered" - {
-
-            "must output the expected row" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, true)
-                .set(ConsigneeAddressPage, userAddressModelMax)
-              )
-
-              DestinationAddressSummary.row() mustBe
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(userAddressModelMax.toCheckYourAnswersFormat),
-                  actions = Seq.empty
-                )
-            }
+            DestinationAddressSummary.row() mustBe expectedSummary(Value(userAddressModelMax.toCheckYourAnswersFormat))
           }
         }
       }
     }
   }
+
+  private def expectedSummary(value: Value)(implicit messagesForLanguage: DestinationAddressMessages.ViewMessages): SummaryListRow =
+    SummaryListRowViewModel(
+      key = Key(Text(messagesForLanguage.cyaLabel)),
+      value = value,
+      actions = Seq(
+        ActionItemViewModel(
+          content = Text(messagesForLanguage.change),
+          href = controllers.sections.destination.routes.DestinationAddressController.onPageLoad(testErn, testDraftId, CheckMode).url,
+          id = "changeDestinationAddress"
+        ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
+      )
+    )
 }

--- a/test/viewmodels/checkAnswers/sections/destination/DestinationBusinessNameSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/destination/DestinationBusinessNameSummarySpec.scala
@@ -20,11 +20,11 @@ import base.SpecBase
 import fixtures.messages.sections.destination.DestinationBusinessNameMessages
 import models.CheckMode
 import org.scalatest.matchers.must.Matchers
-import pages.sections.consignee.ConsigneeBusinessNamePage
 import pages.sections.destination.{DestinationBusinessNamePage, DestinationConsigneeDetailsPage}
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
-import uk.gov.hmrc.govukfrontend.views.Aliases.Value
+import uk.gov.hmrc.govukfrontend.views.Aliases.{Text, Value}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
@@ -32,119 +32,48 @@ class DestinationBusinessNameSummarySpec extends SpecBase with Matchers {
 
   "DestinationBusinessNameSummary" - {
 
-    Seq(DestinationBusinessNameMessages.English).foreach { messagesForLanguage =>
+    Seq(DestinationBusinessNameMessages.English).foreach { implicit messagesForLanguage =>
 
       s"when being rendered in lang code of '${messagesForLanguage.lang.code}'" - {
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        "when there's no answer" - {
+        "when there's no answer for the DestinationBusinessName" - {
 
           "must output row with 'Not provided' and change link" in {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
-            DestinationBusinessNameSummary.row() mustBe SummaryListRowViewModel(
-              key = messagesForLanguage.cyaLabel,
-              value = Value(messagesForLanguage.cyaDestinationNotProvided),
-              actions = Seq(
-                ActionItemViewModel(
-                  content = messagesForLanguage.change,
-                  href = controllers.sections.destination.routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, CheckMode).url,
-                  id = "changeDestinationBusinessName"
-                ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
-              )
+            DestinationBusinessNameSummary.row() mustBe expectedSummary(Value(messagesForLanguage.cyaDestinationNotProvided))
+          }
+        }
+
+        "when Destination BusinessName has been answered" - {
+
+          "must output the expected row" in {
+
+            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
+              .set(DestinationConsigneeDetailsPage, false)
+              .set(DestinationBusinessNamePage, "destination name")
             )
 
-          }
-        }
-
-        "when the DestinationConsigneeDetailsPage has been answered no" - {
-
-          "when there is no Destination BusinessName given" - {
-
-            s"must output ${messagesForLanguage.cyaDestinationNotProvided}" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, false)
-              )
-
-              DestinationBusinessNameSummary.row() mustBe SummaryListRowViewModel(
-                key = messagesForLanguage.cyaLabel,
-                value = Value(messagesForLanguage.cyaDestinationNotProvided),
-                actions = Seq(
-                  ActionItemViewModel(
-                    content = messagesForLanguage.change,
-                    href = controllers.sections.destination.routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, CheckMode).url,
-                    id = "changeDestinationBusinessName"
-                  ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
-                )
-              )
-            }
-          }
-
-          "when Destination BusinessName has been answered" - {
-
-            "must output the expected row" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, false)
-                .set(DestinationBusinessNamePage, "destination name")
-              )
-
-              DestinationBusinessNameSummary.row() mustBe
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value("destination name"),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = controllers.sections.destination.routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, CheckMode).url,
-                      id = "changeDestinationBusinessName"
-                    ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
-                  )
-                )
-            }
-          }
-        }
-
-        "when the DestinationConsigneeDetailsPage has been answered yes" - {
-
-          "when there is no Consignee BusinessName given" - {
-
-            s"must output ${messagesForLanguage.cyaConsigneeNotProvided}" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, true)
-              )
-
-              DestinationBusinessNameSummary.row() mustBe SummaryListRowViewModel(
-                key = messagesForLanguage.cyaLabel,
-                value = Value(messagesForLanguage.cyaConsigneeNotProvided),
-                actions = Seq.empty
-              )
-            }
-          }
-
-          "when Consignee Business Name has been answered" - {
-
-            "must output the expected row" in {
-
-              implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-                .set(DestinationConsigneeDetailsPage, true)
-                .set(ConsigneeBusinessNamePage, "consignee name")
-              )
-
-              DestinationBusinessNameSummary.row() mustBe
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value("consignee name"),
-                  actions = Seq.empty
-                )
-            }
+            DestinationBusinessNameSummary.row() mustBe expectedSummary(Value("destination name"))
           }
         }
       }
     }
   }
+
+  private def expectedSummary(value: Value)(implicit messagesForLanguage: DestinationBusinessNameMessages.ViewMessages): SummaryListRow =
+    SummaryListRowViewModel(
+      key = Key(Text(messagesForLanguage.cyaLabel)),
+      value = value,
+      actions = Seq(
+        ActionItemViewModel(
+          content = Text(messagesForLanguage.change),
+          href = controllers.sections.destination.routes.DestinationBusinessNameController.onPageLoad(testErn, testDraftId, CheckMode).url,
+          id = "changeDestinationBusinessName"
+        ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
+      )
+    )
 }


### PR DESCRIPTION
- Adds the postcode validation based on the values for the DestinationWarehouseExcise number
- If `Yes` is selected to use ConsigneeDetails then these are now pre-popped on the DestinationName and DestinationAddress pages and the User has to confirm them
- CheckAnswers for the section has been updated to always show change links for Name and Address
- Routing logic has been updated to take the user through the flow even when selecting 'Yes' to use ConsigneeDetails
- If the ERN is changed from GB --> XI or XI --> GB then the DestinationAddress is removed and must be re-captured by the User
- Section Completion logic has been updated as the answer for UseConsignee is irrelevant as there now must be an answer for DispatchName and DispatchAddress page.