### PR TITLE
[ETFE-3883] Remove any packages linked to items if the leading shipping mark package is removed.

### DIFF
--- a/app/controllers/sections/items/ItemPackagingRemovePackageController.scala
+++ b/app/controllers/sections/items/ItemPackagingRemovePackageController.scala
@@ -21,7 +21,7 @@ import forms.sections.items.ItemPackagingRemovePackageFormProvider
 import models.Index
 import models.requests.DataRequest
 import navigation.ItemsNavigator
-import pages.sections.items.ItemsPackagingSectionItems
+import pages.sections.items.{ItemsPackagingSectionItems, ItemsSection}
 import play.api.data.Form
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
@@ -79,7 +79,12 @@ class ItemPackagingRemovePackageController @Inject()(
   private def handleAnswerRemovalAndRedirect(shouldRemoveItem: Boolean, itemIdx: Index, packageIdx: Index)(ern: String, draftId: String)
                                             (implicit request: DataRequest[_]): Future[Result] = {
     if (shouldRemoveItem) {
-      val cleansedAnswers = request.userAnswers.remove(ItemsPackagingSectionItems(itemIdx, packageIdx))
+
+      val cleansedAnswers =
+        ItemsSection
+          .removeAnyPackagingThatMatchesTheShippingMark(itemIdx, packageIdx)
+          .remove(ItemsPackagingSectionItems(itemIdx, packageIdx))
+
       userAnswersService.set(cleansedAnswers).map {
         _ => Redirect(routes.ItemsPackagingIndexController.onPageLoad(ern, draftId, itemIdx))
       }

--- a/app/controllers/sections/items/ItemPackagingShippingMarksChoiceController.scala
+++ b/app/controllers/sections/items/ItemPackagingShippingMarksChoiceController.scala
@@ -19,9 +19,9 @@ package controllers.sections.items
 import controllers.actions._
 import forms.sections.items.ItemPackagingShippingMarksChoiceFormProvider
 import models.requests.DataRequest
-import models.{Index, Mode, UserAnswers}
+import models.{Index, Mode}
 import navigation.ItemsNavigator
-import pages.sections.items.{ItemPackagingShippingMarksChoicePage, ItemPackagingShippingMarksPage, ItemsSection, ItemsSectionItem, ItemsSectionItems}
+import pages.sections.items.{ItemPackagingShippingMarksChoicePage, ItemPackagingShippingMarksPage, ItemsSection}
 import play.api.data.Form
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}

--- a/app/controllers/sections/items/ItemPackagingShippingMarksChoiceController.scala
+++ b/app/controllers/sections/items/ItemPackagingShippingMarksChoiceController.scala
@@ -19,9 +19,9 @@ package controllers.sections.items
 import controllers.actions._
 import forms.sections.items.ItemPackagingShippingMarksChoiceFormProvider
 import models.requests.DataRequest
-import models.{Index, Mode}
+import models.{Index, Mode, UserAnswers}
 import navigation.ItemsNavigator
-import pages.sections.items.{ItemPackagingShippingMarksChoicePage, ItemPackagingShippingMarksPage}
+import pages.sections.items.{ItemPackagingShippingMarksChoicePage, ItemPackagingShippingMarksPage, ItemsSection, ItemsSectionItem, ItemsSectionItems}
 import play.api.data.Form
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
@@ -79,7 +79,9 @@ class ItemPackagingShippingMarksChoiceController @Inject()(
   private def cleanseSaveAndRedirect(hasShippingMark: Boolean, itemIdx: Index, packageIdx: Index, mode: Mode)
                                     (implicit request: DataRequest[_]): Future[Result] = {
     val cleansedAnswers = if (hasShippingMark) request.userAnswers else {
-      request.userAnswers.remove(ItemPackagingShippingMarksPage(itemIdx, packageIdx))
+      ItemsSection
+        .removeAnyPackagingThatMatchesTheShippingMark(itemIdx, packageIdx)
+        .remove(ItemPackagingShippingMarksPage(itemIdx, packageIdx))
     }
     saveAndRedirect(ItemPackagingShippingMarksChoicePage(itemIdx, packageIdx), hasShippingMark, cleansedAnswers, mode)
   }

--- a/test/controllers/sections/items/ItemPackagingShippingMarksChoiceControllerSpec.scala
+++ b/test/controllers/sections/items/ItemPackagingShippingMarksChoiceControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.sections.items.ItemPackagingShippingMarksChoiceFormProvider
 import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.FakeNavigators.FakeItemsNavigator
-import pages.sections.items.{ItemExciseProductCodePage, ItemPackagingQuantityPage, ItemPackagingShippingMarksChoicePage, ItemSelectPackagingPage}
+import pages.sections.items.{ItemExciseProductCodePage, ItemPackagingQuantityPage, ItemPackagingShippingMarksChoicePage, ItemPackagingShippingMarksPage, ItemSelectPackagingPage}
 import play.api.mvc.{AnyContentAsEmpty, Call}
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
@@ -158,6 +158,33 @@ class ItemPackagingShippingMarksChoiceControllerSpec extends SpecBase with MockU
       MockUserAnswersService.set(expectedUserAnswers).returns(Future.successful(expectedUserAnswers))
 
       val result = controller.onSubmit(testErn, testDraftId, testIndex1, testPackagingIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "true")))
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual testOnwardRoute.url
+    }
+
+    "must delete the shipping Mark and any packaging that contains that shipping mark (when answer is `No`)" in new Test(
+      Some(baseUserAnswers
+        .set(ItemPackagingShippingMarksChoicePage(testIndex1, testPackagingIndex1), true)
+        .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex1), "MarkA")
+        .set(ItemPackagingShippingMarksChoicePage(testIndex1, testPackagingIndex2), true)
+        .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex2), "MarkA")
+        .set(ItemPackagingShippingMarksChoicePage(testIndex2, testPackagingIndex1), true)
+        .set(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex1), "MarkA")
+        .set(ItemPackagingShippingMarksChoicePage(testIndex2, testPackagingIndex2), true)
+        .set(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex2), "MarkB")
+      )
+    ) {
+
+      //All Mark A are removed. MarkB be on item 2 moved to Packaging Index1
+      val expectedUserAnswers = baseUserAnswers
+        .set(ItemPackagingShippingMarksChoicePage(testIndex1, testPackagingIndex1), false)
+        .set(ItemPackagingShippingMarksChoicePage(testIndex2, testPackagingIndex1), true)
+        .set(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex1), "MarkB")
+
+      MockUserAnswersService.set(expectedUserAnswers).returns(Future.successful(expectedUserAnswers))
+
+      val result = controller.onSubmit(testErn, testDraftId, testIndex1, testPackagingIndex1, NormalMode)(request.withFormUrlEncodedBody(("value", "false")))
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual testOnwardRoute.url

--- a/test/pages/sections/items/ItemsSectionSpec.scala
+++ b/test/pages/sections/items/ItemsSectionSpec.scala
@@ -299,4 +299,69 @@ class ItemsSectionSpec extends SpecBase with ItemFixtures with MovementSubmissio
       }
     }
   }
+
+  "removeAnyPackagingThatMatchesTheShippingMark" - {
+    "when there are shipping marks linked to other packages" - {
+      "must return a UserAnswers with the packaging removed" in {
+
+        val userAnswers =
+          emptyUserAnswers
+            .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex1), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex1, testPackagingIndex1), "1")
+            .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex2), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex1, testPackagingIndex2), "0")
+            .set(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex1), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex2, testPackagingIndex1), "0")
+            .set(ItemPackagingShippingMarksPage(testIndex3, testPackagingIndex1), "Mark2")
+            .set(ItemPackagingQuantityPage(testIndex3, testPackagingIndex1), "1")
+
+        implicit val req = dataRequest(FakeRequest(), userAnswers)
+
+        ItemsSection.removeAnyPackagingThatMatchesTheShippingMark(testIndex1, testPackagingIndex1) mustBe userAnswers
+          .remove(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex2))
+          .remove(ItemPackagingQuantityPage(testIndex1, testPackagingIndex2))
+          .remove(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex1))
+          .remove(ItemPackagingQuantityPage(testIndex2, testPackagingIndex1))
+      }
+    }
+
+    "when there are no shipping marks linked to other packages" - {
+      "must return a UserAnswers unchanged" in {
+
+        val userAnswers =
+          emptyUserAnswers
+            .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex1), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex1, testPackagingIndex1), "1")
+            .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex2), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex1, testPackagingIndex2), "0")
+            .set(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex1), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex2, testPackagingIndex1), "0")
+            .set(ItemPackagingShippingMarksPage(testIndex3, testPackagingIndex1), "Mark2")
+            .set(ItemPackagingQuantityPage(testIndex3, testPackagingIndex1), "1")
+
+        implicit val req = dataRequest(FakeRequest(), userAnswers)
+
+        ItemsSection.removeAnyPackagingThatMatchesTheShippingMark(testIndex3, testPackagingIndex1) mustBe userAnswers
+      }
+    }
+
+    "when no shipping marks linked to the package being removed" - {
+      "must return a UserAnswers unchanged" in {
+
+        val userAnswers =
+          emptyUserAnswers
+            .set(ItemPackagingQuantityPage(testIndex1, testPackagingIndex1), "1")
+            .set(ItemPackagingShippingMarksPage(testIndex1, testPackagingIndex2), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex1, testPackagingIndex2), "0")
+            .set(ItemPackagingShippingMarksPage(testIndex2, testPackagingIndex1), "Mark1")
+            .set(ItemPackagingQuantityPage(testIndex2, testPackagingIndex1), "0")
+            .set(ItemPackagingShippingMarksPage(testIndex3, testPackagingIndex1), "Mark2")
+            .set(ItemPackagingQuantityPage(testIndex3, testPackagingIndex1), "1")
+
+        implicit val req = dataRequest(FakeRequest(), userAnswers)
+
+        ItemsSection.removeAnyPackagingThatMatchesTheShippingMark(testIndex1, testPackagingIndex1) mustBe userAnswers
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR cleanses answers in the items section. If a Shipping Mark is removed, and this would lead to orphaned shipping marks with no parent, then the orphaned child packaging items where the item quantity is zero and the shipping mark is the same is removed.