### PR TITLE
[ETFE-4180] change XIPA guard to XIPC for temp auth code, add feature switch to block XIPC from coming into CaM

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -40,7 +40,7 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, configuration: Configu
   def betaBannerFeedbackUrl(implicit request: RequestHeader): String =
     s"$contactHost/contact/beta-feedback?service=$deskproName&backUrl=${SafeRedirectUrl(host + request.uri).encodedUrl}"
 
-  lazy val loginUrl: String = configuration.get[String]("urls.login")
+  def loginUrl: String = configuration.get[String]("urls.login")
 
   def loginContinueUrl(ern: String): String = configuration.get[String]("urls.loginContinue") + s"/trader/$ern"
 
@@ -128,6 +128,8 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, configuration: Configu
   def maxDispatchDateFutureDays: Int = configuration.get[Int]("constants.maxDispatchDateFutureDays")
 
   def betaAllowListCheckingEnabled: Boolean = isEnabled(CheckBetaAllowList)
+
+  def enableXIPCInCaM: Boolean = isEnabled(EnableXIPCInCaM)
 
   def betaCheckServiceName: String = configuration.get[String]("beta.serviceName")
 }

--- a/app/controllers/sections/consignor/ConsignorIndexController.scala
+++ b/app/controllers/sections/consignor/ConsignorIndexController.scala
@@ -18,7 +18,7 @@ package controllers.sections.consignor
 
 import controllers.BaseNavigationController
 import controllers.actions._
-import models.{NormalMode, NorthernIrelandCertifiedConsignor}
+import models.{NormalMode, NorthernIrelandTemporaryCertifiedConsignor}
 import navigation.ConsignorNavigator
 import pages.sections.consignor.ConsignorSection
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -39,7 +39,7 @@ class ConsignorIndexController @Inject()(override val userAnswersService: UserAn
     authorisedDataRequest(ern, draftId) { implicit request =>
       if (ConsignorSection.isCompleted) {
         Redirect(controllers.sections.consignor.routes.CheckYourAnswersConsignorController.onPageLoad(ern, draftId))
-      } else if (request.userTypeFromErn == NorthernIrelandCertifiedConsignor) {
+      } else if (request.userTypeFromErn == NorthernIrelandTemporaryCertifiedConsignor) {
         Redirect(controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(ern, draftId, NormalMode))
       } else {
         Redirect(controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(ern, draftId, NormalMode))

--- a/app/controllers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeController.scala
+++ b/app/controllers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeController.scala
@@ -20,7 +20,7 @@ import controllers.BaseNavigationController
 import controllers.actions._
 import forms.sections.consignor.ConsignorPaidTemporaryAuthorisationCodeFormProvider
 import models.requests.DataRequest
-import models.{Mode, NormalMode, NorthernIrelandCertifiedConsignor}
+import models.{Mode, NormalMode, NorthernIrelandTemporaryCertifiedConsignor}
 import navigation.ConsignorNavigator
 import pages.sections.consignor.ConsignorPaidTemporaryAuthorisationCodePage
 import play.api.data.Form
@@ -64,7 +64,7 @@ class ConsignorPaidTemporaryAuthorisationCodeController @Inject()(
 
   private[consignor] def authorisedForController(f: Future[Result])(implicit request: DataRequest[_]): Future[Result] =
     request.userTypeFromErn match {
-      case NorthernIrelandCertifiedConsignor => f
+      case NorthernIrelandTemporaryCertifiedConsignor => f
       case _ => Future.successful(
         Redirect(routes.ConsignorAddressController.onPageLoad(request.ern, request.draftId, NormalMode))
       )

--- a/app/featureswitch/core/config/FeatureSwitchingModule.scala
+++ b/app/featureswitch/core/config/FeatureSwitchingModule.scala
@@ -25,7 +25,7 @@ import javax.inject.Singleton
 @Singleton
 class FeatureSwitchingModule extends Module with FeatureSwitchRegistry {
 
-  val switches: Seq[FeatureSwitch] = Seq(CheckBetaAllowList, StubGetTraderKnownFacts, RedirectToFeedbackSurvey, ReturnToLegacy)
+  val switches: Seq[FeatureSwitch] = Seq(CheckBetaAllowList, StubGetTraderKnownFacts, RedirectToFeedbackSurvey, ReturnToLegacy, EnableXIPCInCaM)
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
     Seq(
@@ -52,4 +52,9 @@ case object RedirectToFeedbackSurvey extends FeatureSwitch {
 case object ReturnToLegacy extends FeatureSwitch {
   override val configName: String = "features.returnToLegacy"
   override val displayName: String = "Return the User to the Legacy EMCS service"
+}
+
+case object EnableXIPCInCaM extends FeatureSwitch {
+  override val configName: String = "features.enableXIPCInCaM"
+  override val displayName: String = "Enables XIPC users in CaM"
 }

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -45,7 +45,7 @@ case class DataRequest[A](request: UserRequest[A],
     case Some(dp) if dp == NorthernIreland => Some(NorthernIreland)
     case None if !isNorthernIrelandErn => Some(GreatBritain)
     case value =>
-      logger.warn(s"[dispatchPlace] Invalid value for DISPATCH_PLACE: $value")
+      logger.debug(s"[dispatchPlace] Invalid value for DISPATCH_PLACE: $value")
       None
   }
 }

--- a/app/models/submitCreateMovement/TraderModel.scala
+++ b/app/models/submitCreateMovement/TraderModel.scala
@@ -21,7 +21,7 @@ import models.requests.DataRequest
 import models.sections.guarantor.GuarantorArranger
 import models.sections.info.movementScenario.MovementScenario
 import models.sections.transportArranger.TransportArranger
-import models.{NorthernIrelandCertifiedConsignor, UserAddress}
+import models.{NorthernIrelandTemporaryCertifiedConsignor, UserAddress}
 import pages.sections.consignee._
 import pages.sections.consignor._
 import pages.sections.destination._
@@ -65,7 +65,7 @@ object TraderModel extends ModelConstructorHelpers {
   def applyConsignor(implicit request: DataRequest[_]): TraderModel = {
     val consignorAddress: UserAddress = mandatoryPage(ConsignorAddressPage)
 
-    val ern = if (request.userTypeFromErn == NorthernIrelandCertifiedConsignor) {
+    val ern = if (request.userTypeFromErn == NorthernIrelandTemporaryCertifiedConsignor) {
       mandatoryPage(ConsignorPaidTemporaryAuthorisationCodePage)
     } else {
       request.ern

--- a/app/pages/sections/consignor/ConsignorSection.scala
+++ b/app/pages/sections/consignor/ConsignorSection.scala
@@ -16,7 +16,7 @@
 
 package pages.sections.consignor
 
-import models.NorthernIrelandCertifiedConsignor
+import models.NorthernIrelandTemporaryCertifiedConsignor
 import models.requests.DataRequest
 import pages.sections.Section
 import play.api.libs.json.{JsObject, JsPath}
@@ -31,11 +31,11 @@ case object ConsignorSection extends Section[JsObject] {
       request.userAnswers.get(ConsignorPaidTemporaryAuthorisationCodePage),
       request.userAnswers.get(ConsignorAddressPage)
     ) match {
-      case (NorthernIrelandCertifiedConsignor, Some(_), Some(_)) =>
+      case (NorthernIrelandTemporaryCertifiedConsignor, Some(_), Some(_)) =>
         Completed
-      case (NorthernIrelandCertifiedConsignor, ptaCodePage, addressPage) if ptaCodePage.nonEmpty || addressPage.nonEmpty =>
+      case (NorthernIrelandTemporaryCertifiedConsignor, ptaCodePage, addressPage) if ptaCodePage.nonEmpty || addressPage.nonEmpty =>
         InProgress
-      case (NorthernIrelandCertifiedConsignor, None, None) =>
+      case (NorthernIrelandTemporaryCertifiedConsignor, None, None) =>
         NotStarted
       case (_, _, None) =>
         NotStarted

--- a/app/services/GetExciseProductCodesService.scala
+++ b/app/services/GetExciseProductCodesService.scala
@@ -21,7 +21,7 @@ import models.requests.DataRequest
 import models.response.ExciseProductCodesException
 import models.sections.info.movementScenario.MovementScenario.UnknownDestination
 import models.sections.info.movementScenario.MovementType
-import models.{ExciseProductCode, NorthernIrelandCertifiedConsignor}
+import models.{ExciseProductCode, NorthernIrelandTemporaryCertifiedConsignor}
 import pages.sections.guarantor.GuarantorRequiredPage
 import pages.sections.info.DestinationTypePage
 import uk.gov.hmrc.http.HeaderCarrier
@@ -45,9 +45,9 @@ class GetExciseProductCodesService @Inject()(connector: GetExciseProductCodesCon
 
   private[services] def removeS600IfDutySuspendedMovement()(implicit request: DataRequest[_]): PartialFunction[Seq[ExciseProductCode], Seq[ExciseProductCode]] =
     epcs =>
-      //Only include S600 in list if consignor ERN = XIPA/ XIPTA (user is/should be asked for an XIPTA as part of a XIPA flow)
+      //Only include S600 in list if consignor ERN = XIPC/ XIPTA (user is/should be asked for an XIPTA as part of a XIPC flow)
       request.userTypeFromErn match {
-        case NorthernIrelandCertifiedConsignor => epcs
+        case NorthernIrelandTemporaryCertifiedConsignor => epcs
         case _ => epcs.filterNot(_.code == "S600")
       }
 

--- a/app/viewmodels/checkAnswers/sections/consignor/ConsignorERNSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/consignor/ConsignorERNSummary.scala
@@ -16,7 +16,7 @@
 
 package viewmodels.checkAnswers.sections.consignor
 
-import models.NorthernIrelandCertifiedConsignor
+import models.NorthernIrelandTemporaryCertifiedConsignor
 import models.requests.DataRequest
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
@@ -26,7 +26,7 @@ import viewmodels.implicits._
 object ConsignorERNSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
-    Option.when(request.userTypeFromErn != NorthernIrelandCertifiedConsignor) {
+    Option.when(request.userTypeFromErn != NorthernIrelandTemporaryCertifiedConsignor) {
       SummaryListRowViewModel(
         key = "checkYourAnswersConsignor.ern",
         value = ValueViewModel(request.ern),

--- a/app/viewmodels/checkAnswers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeSummary.scala
@@ -17,7 +17,7 @@
 package viewmodels.checkAnswers.sections.consignor
 
 import models.requests.DataRequest
-import models.{CheckMode, NorthernIrelandCertifiedConsignor}
+import models.{CheckMode, NorthernIrelandTemporaryCertifiedConsignor}
 import pages.sections.consignor.ConsignorPaidTemporaryAuthorisationCodePage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
@@ -29,7 +29,7 @@ object ConsignorPaidTemporaryAuthorisationCodeSummary {
 
   def row()(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] =
     request.userAnswers.get(ConsignorPaidTemporaryAuthorisationCodePage).flatMap { ptaCode =>
-      Option.when(request.userTypeFromErn == NorthernIrelandCertifiedConsignor) {
+      Option.when(request.userTypeFromErn == NorthernIrelandTemporaryCertifiedConsignor) {
         SummaryListRowViewModel(
           key = "checkYourAnswersConsignor.paidTemporaryAuthorisationCode",
           value = ValueViewModel(HtmlFormat.escape(ptaCode).toString),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -151,12 +151,11 @@ tracking-consent-frontend {
 }
 
 features {
-  welsh-translation: false
-  stub-address-lookup-journey: false
   stub-get-trader-known-facts: true
   redirectToFeedbackSurvey: false
   returnToLegacy: false
   checkBetaAllowList: false
+  enableXIPCInCaM = true
 }
 
 internal-auth {

--- a/test/controllers/sections/consignor/ConsignorIndexControllerSpec.scala
+++ b/test/controllers/sections/consignor/ConsignorIndexControllerSpec.scala
@@ -54,25 +54,25 @@ class ConsignorIndexControllerSpec extends SpecBase with MockUserAnswersService 
     }
 
     "when ConsignorSection.isCompleted is false" - {
-      "and logged in as a NorthernIrelandCertifiedConsignor" - {
+      "and logged in as a NorthernIrelandTemporaryCertifiedConsignor" - {
         "must redirect to ConsignorPaidTemporaryAuthorisationCodeController" in
-          new Fixture(Some(emptyUserAnswers.copy(ern = testNICertifiedConsignorErn))) {
-            val result = testController.onPageLoad(testNICertifiedConsignorErn, testDraftId)(request)
-
-            status(result) mustEqual SEE_OTHER
-            redirectLocation(result) mustBe
-              Some(controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode).url)
-          }
-
-      }
-      "and NOT logged in as a NorthernIrelandCertifiedConsignor" - {
-        "must redirect to ConsignorAddressController" in
           new Fixture(Some(emptyUserAnswers.copy(ern = testNITemporaryCertifiedConsignorErn))) {
             val result = testController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId)(request)
 
             status(result) mustEqual SEE_OTHER
             redirectLocation(result) mustBe
-              Some(controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode).url)
+              Some(controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode).url)
+          }
+
+      }
+      "and NOT logged in as a NorthernIrelandTemporaryCertifiedConsignor" - {
+        "must redirect to ConsignorAddressController" in
+          new Fixture(Some(emptyUserAnswers.copy(ern = testNICertifiedConsignorErn))) {
+            val result = testController.onPageLoad(testNICertifiedConsignorErn, testDraftId)(request)
+
+            status(result) mustEqual SEE_OTHER
+            redirectLocation(result) mustBe
+              Some(controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode).url)
           }
       }
     }

--- a/test/controllers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeControllerSpec.scala
+++ b/test/controllers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeControllerSpec.scala
@@ -60,12 +60,12 @@ class ConsignorPaidTemporaryAuthorisationCodeControllerSpec extends SpecBase wit
   }
 
   "ConsignorPaidTemporaryAuthorisationCode Controller" - {
-    "when logged in as a NorthernIrelandCertifiedConsignor user" - {
-      val onSubmit = routes.ConsignorPaidTemporaryAuthorisationCodeController.onSubmit(testNICertifiedConsignorErn, testDraftId, NormalMode)
-      val userAnswers = emptyUserAnswers.copy(ern = testNICertifiedConsignorErn)
+    "when logged in as a NorthernIrelandTemporaryCertifiedConsignor user" - {
+      val onSubmit = routes.ConsignorPaidTemporaryAuthorisationCodeController.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)
+      val userAnswers = emptyUserAnswers.copy(ern = testNITemporaryCertifiedConsignorErn)
 
       "must return OK and the correct view for a GET" in new Test(Some(userAnswers)) {
-        val result = controller.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode)(request)
+        val result = controller.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request)
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(form, onSubmit)(dr, messages(request)).toString
@@ -73,7 +73,7 @@ class ConsignorPaidTemporaryAuthorisationCodeControllerSpec extends SpecBase wit
 
       "must populate the view correctly on a GET when the question has previously been answered" in
         new Test(Some(userAnswers.set(ConsignorPaidTemporaryAuthorisationCodePage, "answer"))) {
-          val result = controller.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode)(request)
+          val result = controller.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request)
 
           status(result) mustEqual OK
           contentAsString(result) mustEqual view(form.fill("answer"), onSubmit)(dr, messages(request)).toString
@@ -82,7 +82,7 @@ class ConsignorPaidTemporaryAuthorisationCodeControllerSpec extends SpecBase wit
       "must redirect to the next page when valid data is submitted" in new Test(Some(userAnswers)) {
         MockUserAnswersService.set().returns(Future.successful(userAnswers))
 
-        val result = controller.onSubmit(testNICertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "XIPTA12345678")))
+        val result = controller.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "XIPTA12345678")))
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual testOnwardRoute.url
@@ -91,7 +91,7 @@ class ConsignorPaidTemporaryAuthorisationCodeControllerSpec extends SpecBase wit
       "must return a Bad Request and errors when an incorrect formatted PTA code is submitted" in new Test(Some(userAnswers)) {
         val boundForm = form.bind(Map("value" -> testGreatBritainErn))
 
-        val result = controller.onSubmit(testNICertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", testGreatBritainErn)))
+        val result = controller.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", testGreatBritainErn)))
 
         status(result) mustEqual BAD_REQUEST
         contentAsString(result) mustEqual view(boundForm, onSubmit)(dr, messages(request)).toString
@@ -100,47 +100,47 @@ class ConsignorPaidTemporaryAuthorisationCodeControllerSpec extends SpecBase wit
       "must return a Bad Request and errors when a blank value is submitted" in new Test(Some(userAnswers)) {
         val boundForm = form.bind(Map("value" -> ""))
 
-        val result = controller.onSubmit(testNICertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "")))
+        val result = controller.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "")))
 
         status(result) mustEqual BAD_REQUEST
         contentAsString(result) mustEqual view(boundForm, onSubmit)(dr, messages(request)).toString
       }
 
       "must redirect to Journey Recovery for a GET if no existing data is found" in new Test(None) {
-        val result = controller.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode)(request)
+        val result = controller.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request)
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
       }
 
       "must redirect to Journey Recovery for a POST if no existing data is found" in new Test(None) {
-        val result = controller.onSubmit(testNICertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "answer")))
+        val result = controller.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "answer")))
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
       }
     }
 
-    "when NOT logged in as a NorthernIrelandCertifiedConsignor user" - {
-      val userAnswers = emptyUserAnswers.copy(ern = testNITemporaryCertifiedConsignorErn)
+    "when NOT logged in as a NorthernIrelandTemporaryCertifiedConsignor user" - {
+      val userAnswers = emptyUserAnswers.copy(ern = testNICertifiedConsignorErn)
 
       "for a GET request" - {
         "must direct to ConsignorAddressController" in new Test(Some(userAnswers)) {
-          val result = controller.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request)
+          val result = controller.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode)(request)
 
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual
-            controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode).url
+            controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode).url
         }
       }
 
       "for a POST request" - {
         "must direct to ConsignorAddressController" in new Test(Some(userAnswers)) {
-          val result = controller.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "answer")))
+          val result = controller.onSubmit(testNICertifiedConsignorErn, testDraftId, NormalMode)(request.withFormUrlEncodedBody(("value", "answer")))
 
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual
-            controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, NormalMode).url
+            controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNICertifiedConsignorErn, testDraftId, NormalMode).url
         }
       }
     }

--- a/test/mocks/config/MockAppConfig.scala
+++ b/test/mocks/config/MockAppConfig.scala
@@ -17,7 +17,7 @@
 package mocks.config
 
 import config.AppConfig
-import org.scalamock.handlers.CallHandler0
+import org.scalamock.handlers.{CallHandler0, CallHandler1}
 import org.scalamock.scalatest.MockFactory
 
 import java.time.LocalDate
@@ -26,6 +26,9 @@ trait MockAppConfig extends MockFactory {
   lazy val mockAppConfig: AppConfig = mock[AppConfig]
 
   object MockAppConfig {
+    def loginUrl: CallHandler0[String] = (mockAppConfig.loginUrl _).expects()
+    def loginContinueUrl: CallHandler1[String, String] = (mockAppConfig.loginContinueUrl(_: String)).expects(*)
+    def enableXIPCInCaM: CallHandler0[Boolean] = (mockAppConfig.enableXIPCInCaM _).expects()
     def destinationOfficeSuffix: CallHandler0[String] = (mockAppConfig.destinationOfficeSuffix _).expects()
     def betaAllowListCheckingEnabled: CallHandler0[Boolean] = (mockAppConfig.betaAllowListCheckingEnabled _).expects()
     def maxDispatchDateFutureDays: CallHandler0[Int] = (mockAppConfig.maxDispatchDateFutureDays _).expects()

--- a/test/models/submitCreateMovement/TraderModelSpec.scala
+++ b/test/models/submitCreateMovement/TraderModelSpec.scala
@@ -183,20 +183,20 @@ class TraderModelSpec extends SpecBase {
 
   "applyConsignor" - {
 
-    "when logged in as a NorthernIrelandCertifiedConsignor user" - {
+    "when logged in as a NorthernIrelandTemporaryCertifiedConsignor user" - {
 
       "must return a TraderModel using the PTA code as the ERN" in {
-        val userAnswers = emptyUserAnswers.copy(ern = testNICertifiedConsignorErn)
+        val userAnswers = emptyUserAnswers.copy(ern = testNITemporaryCertifiedConsignorErn)
           .set(ConsignorPaidTemporaryAuthorisationCodePage, testPaidTemporaryAuthorisationCode)
           .set(ConsignorAddressPage, testUserAddress.copy(street = "consignor street"))
 
-        implicit val dr: DataRequest[_] = dataRequest(fakeRequest, userAnswers, testNICertifiedConsignorErn)
+        implicit val dr: DataRequest[_] = dataRequest(fakeRequest, userAnswers, testNITemporaryCertifiedConsignorErn)
 
         TraderModel.applyConsignor mustBe consignorTraderWithPtaCode
       }
     }
 
-    "when NOT logged in as a NorthernIrelandCertifiedConsignor user" - {
+    "when NOT logged in as a NorthernIrelandTemporaryCertifiedConsignor user" - {
 
       "must return a TraderModel using the logged in user's ERN" in {
         val userAnswers = emptyUserAnswers.copy(ern = testErn)

--- a/test/pages/sections/consignor/ConsignorSectionSpec.scala
+++ b/test/pages/sections/consignor/ConsignorSectionSpec.scala
@@ -24,7 +24,7 @@ class ConsignorSectionSpec extends SpecBase {
 
   "isCompleted" - {
 
-    "for a NorthernIrelandCertifiedConsignor logged in trader" - {
+    "for a NorthernIrelandTemporaryCertifiedConsignor logged in trader" - {
 
       "must return true" - {
         "when both the PTA code and address have been provided" in {
@@ -33,7 +33,7 @@ class ConsignorSectionSpec extends SpecBase {
             answers = emptyUserAnswers
               .set(ConsignorPaidTemporaryAuthorisationCodePage, testPaidTemporaryAuthorisationCode)
               .set(ConsignorAddressPage, testUserAddress),
-            ern = testNICertifiedConsignorErn
+            ern = testNITemporaryCertifiedConsignorErn
           )
 
           ConsignorSection.isCompleted mustBe true
@@ -46,7 +46,7 @@ class ConsignorSectionSpec extends SpecBase {
             request = FakeRequest(),
             answers = emptyUserAnswers
               .set(ConsignorPaidTemporaryAuthorisationCodePage, testPaidTemporaryAuthorisationCode),
-            ern = testNICertifiedConsignorErn
+            ern = testNITemporaryCertifiedConsignorErn
           )
 
           ConsignorSection.isCompleted mustBe false
@@ -56,7 +56,7 @@ class ConsignorSectionSpec extends SpecBase {
             request = FakeRequest(),
             answers = emptyUserAnswers
               .set(ConsignorAddressPage, testUserAddress),
-            ern = testNICertifiedConsignorErn
+            ern = testNITemporaryCertifiedConsignorErn
           )
 
           ConsignorSection.isCompleted mustBe false
@@ -65,7 +65,7 @@ class ConsignorSectionSpec extends SpecBase {
           implicit val dr: DataRequest[_] = dataRequest(
             request = FakeRequest(),
             answers = emptyUserAnswers,
-            ern = testNICertifiedConsignorErn)
+            ern = testNITemporaryCertifiedConsignorErn)
 
           ConsignorSection.isCompleted mustBe false
         }
@@ -75,14 +75,14 @@ class ConsignorSectionSpec extends SpecBase {
 
     }
 
-    "NOT for a NorthernIrelandCertifiedConsignor logged in trader" - {
+    "NOT for a NorthernIrelandTemporaryCertifiedConsignor logged in trader" - {
 
       "must return true" - {
         "when the address has been provided" in {
           implicit val dr: DataRequest[_] = dataRequest(
             request = FakeRequest(),
             answers = emptyUserAnswers.set(ConsignorAddressPage, testUserAddress),
-            ern = testNITemporaryCertifiedConsignorErn
+            ern = testNICertifiedConsignorErn
           )
 
           ConsignorSection.isCompleted mustBe true
@@ -93,7 +93,7 @@ class ConsignorSectionSpec extends SpecBase {
           implicit val dr: DataRequest[_] = dataRequest(
             request = FakeRequest(),
             answers = emptyUserAnswers,
-            ern = testNITemporaryCertifiedConsignorErn
+            ern = testNICertifiedConsignorErn
           )
 
           ConsignorSection.isCompleted mustBe false

--- a/test/services/GetExciseProductCodesServiceSpec.scala
+++ b/test/services/GetExciseProductCodesServiceSpec.scala
@@ -137,10 +137,10 @@ class GetExciseProductCodesServiceSpec extends SpecBase with MockGetExciseProduc
 
       }
 
-      "when Connector returns success from downstream, trader is XIPA - include S600 in results" in {
+      "when Connector returns success from downstream, trader is XIPC - include S600 in results" in {
         implicit val request: DataRequest[_] = dataRequest(
           FakeRequest(),
-          ern = testNICertifiedConsignorErn
+          ern = testNITemporaryCertifiedConsignorErn
         )
 
         val expectedResult = Seq(beerExciseProductCode, wineExciseProductCode, wineExciseProductCode300, spiritExciseProductCode, s600ExciseProductCode, energyExciseProductCode)

--- a/test/viewmodels/checkAnswers/sections/consignor/ConsignorCheckAnswersHelperSpec.scala
+++ b/test/viewmodels/checkAnswers/sections/consignor/ConsignorCheckAnswersHelperSpec.scala
@@ -41,8 +41,8 @@ class ConsignorCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures 
 
     ".summaryList" - {
 
-      "should return the correct rows for an XIPA user" in new Setup(
-        baseUserAnswers.set(ConsignorPaidTemporaryAuthorisationCodePage, testNICertifiedConsignorErn), ern = testNICertifiedConsignorErn
+      "should return the correct rows for an XIPC user" in new Setup(
+        baseUserAnswers.set(ConsignorPaidTemporaryAuthorisationCodePage, testNITemporaryCertifiedConsignorErn), ern = testNITemporaryCertifiedConsignorErn
       ) {
 
         val expectedResult: SummaryList = SummaryList(Seq(
@@ -54,7 +54,7 @@ class ConsignorCheckAnswersHelperSpec extends SpecBase with UserAddressFixtures 
         checkAnswersHelper.summaryList() mustBe expectedResult
       }
 
-      "should return the correct rows for a non-XIPA user" in new Setup(baseUserAnswers) {
+      "should return the correct rows for a non-XIPC user" in new Setup(baseUserAnswers) {
 
         val expectedResult: SummaryList = SummaryList(Seq(
           Some(ConsignorTraderNameSummary.row),

--- a/test/viewmodels/checkAnswers/sections/consignor/ConsignorERNSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/consignor/ConsignorERNSummarySpec.scala
@@ -36,21 +36,21 @@ class ConsignorERNSummarySpec extends SpecBase with Matchers {
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        "when the user is an XIPA trader" - {
+        "when the user is an XIPC trader" - {
 
           "must output the expected data" in {
 
-            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, ern = testNICertifiedConsignorErn)
+            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, ern = testNITemporaryCertifiedConsignorErn)
 
             ConsignorERNSummary.row() mustBe None
           }
         }
 
-        "when the user is a non-XIPA trader" - {
+        "when the user is a non-XIPC trader" - {
 
           "must output the expected row" in {
 
-            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, ern = testNITemporaryCertifiedConsignorErn)
+            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, ern = testNICertifiedConsignorErn)
 
             ConsignorERNSummary.row() mustBe
               Some(

--- a/test/viewmodels/checkAnswers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/consignor/ConsignorPaidTemporaryAuthorisationCodeSummarySpec.scala
@@ -38,17 +38,7 @@ class ConsignorPaidTemporaryAuthorisationCodeSummarySpec extends SpecBase with M
 
         implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        "when the user is a non-XIPA trader" - {
-
-          "must output the expected data" in {
-
-            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, ern = testNITemporaryCertifiedConsignorErn)
-
-            ConsignorPaidTemporaryAuthorisationCodeSummary.row() mustBe None
-          }
-        }
-
-        "when the user is an XIPA trader but there is no answer for the page" - {
+        "when the user is a non-XIPC trader" - {
 
           "must output the expected data" in {
 
@@ -58,23 +48,33 @@ class ConsignorPaidTemporaryAuthorisationCodeSummarySpec extends SpecBase with M
           }
         }
 
-        "when the user is an XIPA trader" - {
+        "when the user is an XIPC trader but there is no answer for the page" - {
+
+          "must output the expected data" in {
+
+            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, ern = testNITemporaryCertifiedConsignorErn)
+
+            ConsignorPaidTemporaryAuthorisationCodeSummary.row() mustBe None
+          }
+        }
+
+        "when the user is an XIPC trader" - {
 
           "must output the expected row" in {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-              .set(ConsignorPaidTemporaryAuthorisationCodePage, testNICertifiedConsignorErn),
-              ern = testNICertifiedConsignorErn
+              .set(ConsignorPaidTemporaryAuthorisationCodePage, testNITemporaryCertifiedConsignorErn),
+              ern = testNITemporaryCertifiedConsignorErn
             )
 
             ConsignorPaidTemporaryAuthorisationCodeSummary.row() mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.paidTemporaryAuthorisationCode,
-                  value = Value(Text(testNICertifiedConsignorErn)),
+                  value = Value(Text(testNITemporaryCertifiedConsignorErn)),
                   actions = Seq(ActionItemViewModel(
                     content = Text(messagesForLanguage.change),
-                    href = controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(testNICertifiedConsignorErn, testDraftId, CheckMode).url,
+                    href = controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, CheckMode).url,
                     id = "changeConsignorPaidTemporaryAuthorisationCode"
                   ).withVisuallyHiddenText(messagesForLanguage.paidTemporaryAuthorisationCodeChangeHidden))
                 )

--- a/test/views/sections/consignor/CheckYourAnswersConsignorViewSpec.scala
+++ b/test/views/sections/consignor/CheckYourAnswersConsignorViewSpec.scala
@@ -55,7 +55,7 @@ class CheckYourAnswersConsignorViewSpec extends SpecBase with ViewBehaviours {
 
         val summaryListHelper = app.injector.instanceOf[ConsignorCheckAnswersHelper]
 
-        "for a non-XIPA trader" - {
+        "for a non-XIPC trader" - {
           implicit val doc: Document = Jsoup.parse(view(
             summaryListHelper.summaryList(),
             controllers.sections.consignor.routes.CheckYourAnswersConsignorController.onSubmit(testErn, testDraftId)
@@ -78,16 +78,16 @@ class CheckYourAnswersConsignorViewSpec extends SpecBase with ViewBehaviours {
           }
         }
 
-        "for an XIPA trader" - {
+        "for an XIPC trader" - {
 
           implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), emptyUserAnswers
             .set(ConsignorPaidTemporaryAuthorisationCodePage, testPaidTemporaryAuthorisationCode)
             .set(ConsignorAddressPage, testUserAddress),
-            ern = testNICertifiedConsignorErn)
+            ern = testNITemporaryCertifiedConsignorErn)
 
           implicit val doc: Document = Jsoup.parse(view(
             summaryListHelper.summaryList(),
-            controllers.sections.consignor.routes.CheckYourAnswersConsignorController.onSubmit(testNICertifiedConsignorErn, testDraftId)
+            controllers.sections.consignor.routes.CheckYourAnswersConsignorController.onSubmit(testNITemporaryCertifiedConsignorErn, testDraftId)
           ).toString())
 
           behave like pageWithExpectedElementsAndMessages(Seq(
@@ -103,13 +103,13 @@ class CheckYourAnswersConsignorViewSpec extends SpecBase with ViewBehaviours {
           "have a link to change Paid Temporary Authorisation Code" in {
 
             doc.select(Selectors.changeConsignorPaidTemporaryAuthorisationCodeLink).attr("href") mustBe
-              controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(testNICertifiedConsignorErn, testDraftId, CheckMode).url
+              controllers.sections.consignor.routes.ConsignorPaidTemporaryAuthorisationCodeController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, CheckMode).url
           }
 
           "have a link to change Address details" in {
 
             doc.select(Selectors.changeConsignorAddressLink).attr("href") mustBe
-              controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNICertifiedConsignorErn, testDraftId, CheckMode).url
+              controllers.sections.consignor.routes.ConsignorAddressController.onPageLoad(testNITemporaryCertifiedConsignorErn, testDraftId, CheckMode).url
           }
         }
       }


### PR DESCRIPTION
Related:

- https://github.com/hmrc/app-config-qa/pull/22648
- https://github.com/hmrc/app-config-production/pull/22689