### PR TITLE
[ETFE-4582] Update so that timeoutUrl is separately defined

### DIFF
--- a/app/controllers/auth/SignedOutController.scala
+++ b/app/controllers/auth/SignedOutController.scala
@@ -43,4 +43,14 @@ class SignedOutController @Inject()(
     Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.feedbackFrontendSurveyUrl)))
   }
 
+  def signOut(becauseOfTimeout: Boolean = false): Action[AnyContent] = Action { request =>
+    val savablePage = request.uri.matches(".*/trader/.*/draft/.*")
+    val continue = (becauseOfTimeout, savablePage) match {
+      case (false, _) => appConfig.feedbackFrontendSurveyUrl
+      case (_, true) => appConfig.host + controllers.auth.routes.SignedOutController.signedOutSaved().url
+      case (_, false) => appConfig.host + controllers.auth.routes.SignedOutController.signedOutNotSaved().url
+    }
+    Redirect(appConfig.signOutUrl, Map("continue" -> Seq(continue)))
+  }
+
 }

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -60,6 +60,7 @@
                 keepAliveUrl        = Some(routes.KeepAliveController.keepAlive.url),
                 keepAliveButtonText = Some(messages("timeout.keepAlive")),
                 signOutUrl          = Some(controllers.auth.routes.SignedOutController.signOut().url),
+                timeoutUrl          = Some(controllers.auth.routes.SignedOutController.signOut(true).url),
                 signOutButtonText   = Some(messages("timeout.signOut")),
                 title               = Some(messages("timeout.title")),
                 message             = Some(messages("timeout.message"))

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,7 +12,7 @@ GET         /there-is-a-problem                                 controllers.Jour
 
 GET         /account/signed-out                                 controllers.auth.SignedOutController.signedOutNotSaved()
 GET         /account/signed-out-saved                           controllers.auth.SignedOutController.signedOutSaved()
-GET         /account/sign-out                                   controllers.auth.SignedOutController.signOut()
+GET         /account/sign-out                                   controllers.auth.SignedOutController.signOut(becauseOfTimeout: Boolean ?= false)
 
 GET         /trader/:ern                                        controllers.IndexController.onPageLoad(ern: String)
 


### PR DESCRIPTION
Signs the User out via auth, and then redirects to relevant timeout page - instead of feeback. If the User actively decides to sign out then they are taken to the feedback survey still.