### PR TITLE
[ETFE-4232] Moved the hint on GuarantorVat and FirstTransporterVat

### DIFF
--- a/app/views/sections/firstTransporter/FirstTransporterVatView.scala.html
+++ b/app/views/sections/firstTransporter/FirstTransporterVatView.scala.html
@@ -60,7 +60,6 @@
                 ),
                 legend = LegendViewModel(Text(messages("firstTransporterVat.heading"))).asPageHeading(LegendSize.Large)
             )
-            .withHint(Hint(content = Text(messages("firstTransporterVat.hint"))))
         )
 
         @continueOrExit()
@@ -74,6 +73,7 @@
             label = LabelViewModel(messages("firstTransporterVat.input.label"))
         )
         .withWidth(TwoThirds)
+        .withHint(Hint(content = Text(messages("firstTransporterVat.hint"))))
     )
 }
 

--- a/app/views/sections/guarantor/GuarantorVatView.scala.html
+++ b/app/views/sections/guarantor/GuarantorVatView.scala.html
@@ -58,7 +58,7 @@
                     )
                 ),
                 legend = LegendViewModel(Text(messages(s"guarantorVat.$guarantorArranger.heading"))).asPageHeading(LegendSize.Large)
-            ).withHint(HintViewModel(content = Text(messages("guarantorVat.hint"))))
+            )
         )
 
         @continueOrExit()
@@ -66,10 +66,14 @@
 }
 
 @vatRegistrationNumber = {
-    @govukInput(InputViewModel.apply(
-        form(GuarantorVatFormProvider.vatNumberField),
-        LabelViewModel(Text(messages("guarantorVat.input.label")))
-    ).withWidth(InputWidth.TwoThirds))
+    @govukInput(
+        InputViewModel.apply(
+            form(GuarantorVatFormProvider.vatNumberField),
+            LabelViewModel(Text(messages("guarantorVat.input.label")))
+        )
+        .withWidth(InputWidth.TwoThirds)
+        .withHint(HintViewModel(content = Text(messages("guarantorVat.hint"))))
+    )
 }
 
 @{


### PR DESCRIPTION
Guarantor VAT update:
![Screenshot 2024-10-23 at 15 13 49](https://github.com/user-attachments/assets/82f41c98-589c-43d3-a4f1-3c90cd440a97)

First Transporter VAT update:
![Screenshot 2024-10-23 at 15 14 07](https://github.com/user-attachments/assets/803ef903-bc42-4446-a915-2f1026c5c9fe)

NotUT changes needed as already has selectors for the hint, so visual eyeball only hence the screenshots ☝️  